### PR TITLE
EN-10079/Message verify

### DIFF
--- a/include/transaction/signer.h
+++ b/include/transaction/signer.h
@@ -10,6 +10,10 @@ public:
 
     std::string getSignature(std::string const &message) const;
 
+    bool verify(std::string const &signature, std::string const &message) const;
+
+    static bool verify(std::string const &signature, std::string const &message, bytes const &publicKey);
+
 private:
     bytes m_sk;
 };

--- a/include/transaction/signer.h
+++ b/include/transaction/signer.h
@@ -2,6 +2,7 @@
 #define ERD_SIGNER_H
 
 #include "internal/internal.h"
+#include "account/address.h"
 
 class Signer
 {
@@ -13,6 +14,8 @@ public:
     bool verify(std::string const &signature, std::string const &message) const;
 
     static bool verify(std::string const &signature, std::string const &message, bytes const &publicKey);
+
+    static bool verify(std::string const &signature, std::string const &message, Address const &address);
 
 private:
     bytes m_sk;

--- a/src/transaction/signer.cpp
+++ b/src/transaction/signer.cpp
@@ -16,3 +16,15 @@ std::string Signer::getSignature(std::string const &message) const
 {
     return wrapper::crypto::getSignature(m_sk, message);
 }
+
+bool Signer::verify(std::string const &signature, std::string const &message) const
+{
+    bytes const publicKey = wrapper::crypto::getPublicKey(m_sk);
+
+    return wrapper::crypto::verify(signature, message, publicKey);
+}
+
+bool Signer::verify(std::string const &signature, std::string const &message, bytes const &publicKey)
+{
+    return wrapper::crypto::verify(signature, message, publicKey);
+}

--- a/src/transaction/signer.cpp
+++ b/src/transaction/signer.cpp
@@ -28,3 +28,10 @@ bool Signer::verify(std::string const &signature, std::string const &message, by
 {
     return wrapper::crypto::verify(signature, message, publicKey);
 }
+
+bool Signer::verify(const std::string &signature, const std::string &message, const Address &address)
+{
+    bytes const publicKey = address.getPublicKey();
+
+    return wrapper::crypto::verify(signature, message, publicKey);
+}

--- a/src/wrappers/cryptosignwrapper.cpp
+++ b/src/wrappers/cryptosignwrapper.cpp
@@ -41,6 +41,29 @@ bytes getSecretKey(bytes const &seed)
     return bytes(sk, sk + SECRET_KEY_LENGTH);
 }
 
+bytes getPublicKey(bytes const &secretKey)
+{
+    auto sk = reinterpret_cast<const unsigned char*>(secretKey.data());
+
+    unsigned char pk[PUBLIC_KEY_LENGTH];
+
+    crypto_sign_ed25519_sk_to_pk(pk, sk);
+
+    return bytes(pk, pk + PUBLIC_KEY_LENGTH);
+}
+
+bool verify(std::string const &signature, std::string const &message, bytes const &publicKey)
+{
+    auto sig = reinterpret_cast<const unsigned char*>(signature.data());
+    auto msg = reinterpret_cast<const unsigned char*>(message.data());
+    auto pk = reinterpret_cast<const unsigned char*>(publicKey.data());
+    auto msgLen = message.size();
+
+    int const res = crypto_sign_verify_detached(sig, msg, msgLen, pk);
+
+    return res == 0;
+}
+
 }
 }
 

--- a/src/wrappers/cryptosignwrapper.h
+++ b/src/wrappers/cryptosignwrapper.h
@@ -17,6 +17,10 @@ namespace crypto
 std::string getSignature(bytes const &secretKey, std::string const &message);
 
 bytes getSecretKey(bytes const &seed);
+
+bytes getPublicKey(bytes const &secretKey);
+
+bool verify(std::string const &signature, std::string const &message, bytes const &publicKey);
 }
 }
 

--- a/tests/test_src/test_transaction/test_transaction.cpp
+++ b/tests/test_src/test_transaction/test_transaction.cpp
@@ -4,6 +4,7 @@
 #include "utils/errors.h"
 #include "transaction/signer.h"
 #include "transaction/transaction.h"
+#include "wrappers/cryptosignwrapper.h"
 
 
 class SignerConstructorFixture : public ::testing::Test
@@ -39,7 +40,7 @@ TEST_F(SignerConstructorFixture, invalidSeed)
 
 TEST(Signer, getSignature)
 {
-    bytes seed = util::hexToBytes("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf");
+    bytes const seed = util::hexToBytes("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf");
     Signer signer(seed);
 
     std::string msg = "{\"nonce\":0,\"value\":\"0\",\"receiver\":\"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r\",\"sender\":\"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz\",\"gasPrice\":1000000000,\"gasLimit\":50000,\"data\":\"Zm9v\",\"chainID\":\"1\",\"version\":1}";
@@ -47,6 +48,39 @@ TEST(Signer, getSignature)
     std::string expectedSignature = "b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00";
 
     EXPECT_EQ(util::stringToHex(signature), expectedSignature);
+}
+
+TEST(Signer, verify_signature_by_signer)
+{
+    bytes const seed = util::hexToBytes("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf");
+    Signer signer(seed);
+
+    std::string msg = "{\"nonce\":0,\"value\":\"0\",\"receiver\":\"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r\",\"sender\":\"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz\",\"gasPrice\":1000000000,\"gasLimit\":50000,\"data\":\"Zm9v\",\"chainID\":\"1\",\"version\":1}";
+    std::string signature = util::hexToString("b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00");
+
+    EXPECT_TRUE(signer.verify(signature, msg));
+}
+
+TEST(Signer, verify_signature_by_publicKey)
+{
+    bytes const seed = util::hexToBytes("1a927e2af5306a9bb2ea777f73e06ecc0ac9aaa72fb4ea3fecf659451394cccf");
+    bytes const secretKey = wrapper::crypto::getSecretKey(seed);
+    bytes const publicKey = wrapper::crypto::getPublicKey(secretKey);
+
+    std::string msg = "{\"nonce\":0,\"value\":\"0\",\"receiver\":\"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r\",\"sender\":\"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz\",\"gasPrice\":1000000000,\"gasLimit\":50000,\"data\":\"Zm9v\",\"chainID\":\"1\",\"version\":1}";
+    std::string signature = util::hexToString("b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00");
+
+    EXPECT_TRUE(Signer::verify(signature, msg, publicKey));
+}
+
+TEST(Signer, verify_signature_by_address)
+{
+    Address signerAddr("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz");
+
+    std::string msg = "{\"nonce\":8,\"value\":\"10000000000000000000\",\"receiver\":\"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r\",\"sender\":\"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz\",\"gasPrice\":1000000000,\"gasLimit\":50000,\"chainID\":\"1\",\"version\":1}";
+    std::string signature = util::hexToString("4a6d8186eae110894e7417af82c9bf9592696c0600faf110972e0e5310d8485efc656b867a2336acec2b4c1e5f76c9cc70ba1803c6a46455ed7f1e2989a90105");
+
+    EXPECT_TRUE(Signer::verify(signature, msg, signerAddr));
 }
 
 struct signSerializedTxData

--- a/tests/test_src/test_transaction/test_transaction.cpp
+++ b/tests/test_src/test_transaction/test_transaction.cpp
@@ -6,6 +6,11 @@
 #include "transaction/transaction.h"
 #include "wrappers/cryptosignwrapper.h"
 
+// Most tests for signing and transaction construction are adapted from one of the following sources:
+// ERD-JS: https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/bb926b029150d7c79f2b37308f4334f98a4cabf7/src/testutils/wallets.ts#L110
+//         https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/main/src/walletcore/users.spec.ts#L120
+// ERD-PY: https://github.com/ElrondNetwork/elrond-sdk-erdpy/blob/main/erdpy/tests/test_wallet.py
+// ERD-GO: https://github.com/ElrondNetwork/elrond-go/blob/master/examples/construction_test.go
 
 class SignerConstructorFixture : public ::testing::Test
 {

--- a/tests/test_src/test_wrappers/test_wrappers.cpp
+++ b/tests/test_src/test_wrappers/test_wrappers.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "utils/hex.h"
+#include "account/address.h"
 #include "wrappers/jsonwrapper.h"
 #include "wrappers/httpwrapper.h"
 #include "wrappers/cryptosignwrapper.h"
@@ -149,6 +150,25 @@ TEST(CryptoWrapper, getSignature)
     EXPECT_EQ(signature.size(), SIGNATURE_LENGTH);
     EXPECT_EQ(util::stringToHex(signature), expectedSignature);
 
+}
+
+TEST(CryptoWrapper, getPublicKey)
+{
+    bytes const seed = util::hexToBytes("413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9");
+    bytes const secretKey =  wrapper::crypto::getSecretKey(seed);
+    bytes const expectedPublicKey = util::hexToBytes("0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1");
+
+    EXPECT_EQ(wrapper::crypto::getPublicKey(secretKey), expectedPublicKey);
+}
+
+TEST(CryptoWrapper, verify)
+{
+    std::string const message = "{\"nonce\":0,\"value\":\"0\",\"receiver\":\"erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r\",\"sender\":\"erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz\",\"gasPrice\":1000000000,\"gasLimit\":50000,\"data\":\"Zm9v\",\"chainID\":\"1\",\"version\":1}";
+    std::string const signature = util::hexToString("b5fddb8c16fa7f6123cb32edc854f1e760a3eb62c6dc420b5a4c0473c58befd45b621b31a448c5b59e21428f2bc128c80d0ee1caa4f2bf05a12be857ad451b00");
+
+    Address signerAddr("erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz");
+
+    EXPECT_TRUE(wrapper::crypto::verify(signature, message, signerAddr.getPublicKey()));
 }
 
 TEST(ClientWrapper, get_validSubDomain_validRequest)

--- a/tests/test_src/test_wrappers/test_wrappers.cpp
+++ b/tests/test_src/test_wrappers/test_wrappers.cpp
@@ -125,6 +125,11 @@ TEST_F(OrderedJsonFixture, serialize_empty)
     EXPECT_EQ(json.serialize(), "{\"pi\":3.141,\"happy\":true,\"name\":\"Joe\"}");
 }
 
+// Most tests for crypto library are adapted from one of the following sources:
+// ERDJS: https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/bb926b029150d7c79f2b37308f4334f98a4cabf7/src/testutils/wallets.ts#L110
+//        https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/main/src/walletcore/users.spec.ts#L120
+// ERDPY: https://github.com/ElrondNetwork/elrond-sdk-erdpy/blob/main/erdpy/tests/test_wallet.py
+// ERDGO: https://github.com/ElrondNetwork/elrond-go/blob/master/examples/construction_test.go
 TEST(CryptoWrapper, getSecretKey)
 {
     bytes const seed = util::hexToBytes("e253a571ca153dc2aee845819f74bcc9773b0586edead15a94cb7235a5027436");
@@ -150,7 +155,6 @@ TEST(CryptoWrapper, getSignature)
 
     EXPECT_EQ(signature.size(), SIGNATURE_LENGTH);
     EXPECT_EQ(util::stringToHex(signature), expectedSignature);
-
 }
 
 TEST(CryptoWrapper, getPublicKey)


### PR DESCRIPTION
Added crypto library function wrappers for:
- getPublicKey (from secret key)
- verify (signature, message, public key)

In `Signer`, added verify signed message by:

- signer
- public key
- public address
