### PR TITLE
FEAT: Use integer library instead of gnu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,17 +8,12 @@ project(ERDCPP)
 
 set(LIBSODIUM_INCLUDE_PATH "/usr/local/include")
 set(LIBSODIUM_LIB_PATH "/usr/local/lib")
-set(GMP_INCLUDE_PATH "/usr/lib/include")
-set(GMP_LIB_PATH "/usr/lib")
 
 include_directories(${PROJECT_SOURCE_DIR}/include)
 include_directories(${PROJECT_SOURCE_DIR}/external)
 include_directories(${LIBSODIUM_INCLUDE_PATH})
-include_directories(${GMP_INCLUDE_PATH})
 
 find_library(LIBSODIUM_LIBRARY libsodium.so.23.3.0 ${LIBSODIUM_LIB_PATH} REQUIRED)
-find_library(GMP_LIBRARY libgmp.so.10.4.0 ${GMP_LIB_PATH} REQUIRED)
-find_library(GMPXX_LIBRARY libgmpxx.so.4.6.0 ${GMP_LIB_PATH} REQUIRED)
 
 find_package(OpenSSL REQUIRED)
 if(OPENSSL_FOUND)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ git submodule update --init --recursive
 Elrond C++ SDK CLI uses:
 - Libsodium shared library. Make sure to [install](https://doc.libsodium.org/installation) the
 latest version.
-- GNU GMP. Make sure to install it:
-```bash
-sudo apt-get install libgmp3-dev
-```
 
 ### 1.3 Compile and build with CMake
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -6,6 +6,7 @@ file(GLOB external
         toml/cpptoml.h
         aes_128_ctr/aes.c
         keccak/sha3.c
+        bigint/integer.h bigint/integer.cpp
         )
 
 add_library(external ${external})

--- a/external/bigint/integer.cpp
+++ b/external/bigint/integer.cpp
@@ -1,0 +1,1434 @@
+#include "integer.h"
+
+constexpr INTEGER_DIGIT_T integer::NEG1;
+constexpr std::size_t     integer::OCTETS;
+constexpr std::size_t     integer::BITS;
+constexpr INTEGER_DIGIT_T integer::HIGH_BIT;
+constexpr integer::Sign   integer::POSITIVE;
+constexpr integer::Sign   integer::NEGATIVE;
+
+integer & integer::trim(){                  // remove top 0 digits to save memory
+    while (!_value.empty() && !_value[0]){
+        _value.pop_front();
+    }
+    if (_value.empty()){                    // change sign to false if _value is 0
+        _sign = integer::POSITIVE;
+    }
+
+    return *this;
+}
+
+// Constructors
+integer::integer() :
+    _sign(integer::POSITIVE),
+    _value()
+{}
+
+integer::integer(const integer & copy) :
+    _sign(copy._sign),
+    _value(copy._value)
+{
+    trim();
+}
+
+integer::integer(integer && copy) :
+    _sign(std::move(copy._sign)),
+    _value(std::move(copy._value))
+{
+    copy = 0;
+    trim();
+}
+
+integer::integer(const integer::REP & rhs, const integer::Sign & sign) :
+    _sign(sign),
+    _value(rhs)
+{
+    trim();
+}
+
+integer::integer(const bool & b) :
+    _sign(false),
+    _value(1, b)
+{
+    trim();
+}
+
+// Special Constructor for Strings
+// bases 2-16 and 256 are allowed
+//      Written by Corbin http://codereview.stackexchange.com/a/13452
+//      Modified by me
+integer::integer(const std::string & str, const integer & base) : integer()
+{
+    if ((2 <= base) && (base <= 16)){
+        if (!str.size()){
+            return;
+        }
+
+        integer::Sign sign = integer::POSITIVE;
+
+        std::string::size_type index = 0;
+
+        // minus sign indicates negative value
+        if (str[0] == '-'){
+            // make sure there are more digits
+            if (str.size() < 2){
+                throw std::runtime_error("Error: Input string is too short");
+            }
+
+            sign = integer::NEGATIVE;
+            index++;
+        }
+
+        // process characters
+        for(; index < str.size(); index++){
+            uint8_t d = std::tolower(str[index]);
+            if (std::isdigit(d)){       // 0-9
+                d -= '0';
+                if (d >= base){
+                    throw std::runtime_error(std::string("Error: Not a digit in base ") + base.str(10) + ": '"+ str[index] + "'");
+                }
+            }
+            else if (std::isxdigit(d)){ // a-f
+                d -= 'a' - 10;
+                if (d >= base){
+                    throw std::runtime_error(std::string("Error: Not a digit in base ") + base.str(10) + ": '"+ str[index] + "'");
+                }
+            }
+            else{                       // bad character
+                throw std::runtime_error(std::string("Error: Not a digit in base ") + base.str(10) + ": '"+ str[index] + "'");
+            }
+
+            *this = (*this * base) + d;
+        }
+
+        _sign = sign;
+    }
+    else if (base == 256){
+        // process characters
+        for(unsigned char const & c : str){
+            *this = (*this << 8) | (c & 0xff);
+        }
+    }
+    else{
+        throw std::runtime_error("Error: Cannot convert from base " + base.str(10));
+    }
+
+    trim();
+}
+
+//  RHS input args only
+
+// Assignment Operators
+integer & integer::operator=(const integer & rhs){
+    _sign = rhs._sign;
+    _value = rhs._value;
+    return trim();
+}
+
+integer & integer::operator=(integer && rhs){
+    if (*this != rhs){
+        _sign = rhs._sign;
+        _value = rhs._value;
+        rhs = 0;
+    }
+    return trim();
+}
+
+// Typecast Operators
+integer::operator bool() const {
+    return !_value.empty();
+}
+
+integer::operator uint8_t() const {
+    const uint8_t out = static_cast <uint8_t> (_value.empty()?0:_value.back() & 255);
+    return _sign?-out:out;
+}
+
+integer::operator uint16_t() const {
+    uint16_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 2 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <uint16_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+integer::operator uint32_t() const {
+    uint32_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 4 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <uint32_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+integer::operator uint64_t() const {
+    uint64_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 8 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <uint64_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+integer::operator int8_t() const {
+    const int8_t out = static_cast <int8_t> (_value.empty()?0:_value.back() & 255);
+    return _sign?-out:out;
+}
+
+integer::operator int16_t() const {
+    int16_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 2 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <int16_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+integer::operator int32_t() const {
+    int32_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 4 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <int32_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+integer::operator int64_t() const {
+    int64_t out = 0;
+
+    const integer::REP_SIZE_T d = std::min(digits(), std::max((integer::REP_SIZE_T) 8 / integer::OCTETS, (integer::REP_SIZE_T) 1));
+    for(integer::REP_SIZE_T x = 0; x < d; x++){
+        out += static_cast <int64_t> (_value[digits() - x - 1]) << (x * integer::BITS);
+    }
+
+    return _sign?-out:out;
+}
+
+// Bitwise Operators
+integer integer::operator&(const integer & rhs) const {
+    integer::REP out;
+
+    const integer::REP_SIZE_T max_bits = std::max(bits(), rhs.bits());
+    const integer             left     = (    _sign == integer::POSITIVE)?*this:twos_complement(max_bits);
+    const integer             right    = (rhs._sign == integer::POSITIVE)?rhs:rhs.twos_complement(max_bits);
+
+    // AND matching digits
+    for(integer::REP::const_reverse_iterator i = left._value.rbegin(), j = right._value.rbegin(); (i != left._value.rend()) && (j != right._value.rend()); i++, j++){
+        out.push_front(*i & *j);
+    }
+
+    // drop any digits that don't match up
+
+    integer OUT(out, integer::POSITIVE);
+    if (_sign & rhs._sign){
+        OUT = OUT.twos_complement(max_bits);
+    }
+
+    return OUT.trim();
+}
+
+integer & integer::operator&=(const integer & rhs){
+    return *this = *this & rhs;
+}
+
+integer integer::operator|(const integer & rhs) const {
+    const integer::REP_SIZE_T max_bits = std::max(bits(), rhs.bits());
+    const integer             left     = (    _sign == integer::POSITIVE)?*this:twos_complement(max_bits);
+    const integer             right    = (rhs._sign == integer::POSITIVE)?rhs:rhs.twos_complement(max_bits);
+
+    integer::REP out;
+    integer::REP::const_reverse_iterator i = left._value.rbegin(), j = right._value.rbegin();
+
+    // OR matching digits
+    for(; (i != left._value.rend()) && (j != right._value.rend()); i++, j++){
+        out.push_front(*i | *j);
+    }
+
+    // push rest of *this into value
+    while (i != left._value.rend()){
+        out.push_front(*i++);
+    }
+
+    // push rest of rhs into value
+    while (j != right._value.rend()){
+        out.push_front(*j++);
+    }
+
+    integer OUT(out, integer::POSITIVE);
+    if (_sign | rhs._sign){
+        OUT = OUT.twos_complement(max_bits);
+    }
+
+    return OUT.trim();
+}
+
+integer & integer::operator|=(const integer & rhs){
+    return *this = *this | rhs;
+}
+
+integer integer::operator^(const integer & rhs) const {
+    const integer::REP_SIZE_T max_bits = std::max(bits(), rhs.bits());
+    const integer             left     = (    _sign == integer::POSITIVE)?*this:twos_complement(max_bits);
+    const integer             right    = (rhs._sign == integer::POSITIVE)?rhs:rhs.twos_complement(max_bits);
+
+    integer::REP out;
+    integer::REP::const_reverse_iterator i = left._value.rbegin(), j = right._value.rbegin();
+
+    // XOR matching digits
+    for(; (i != left._value.rend()) && (j != right._value.rend()); i++, j++){
+        out.push_front(*i ^ *j);
+    }
+
+    // push *this into value
+    while (i != left._value.rend()){
+        out.push_front(*i++);
+    }
+
+    // push rhs into value
+    while (j != right._value.rend()){
+        out.push_front(*j++);
+    }
+
+    integer OUT(out, integer::POSITIVE);
+    if (_sign ^ rhs._sign){
+        OUT = OUT.twos_complement(max_bits);
+    }
+
+    return OUT.trim();
+}
+
+integer & integer::operator^=(const integer & rhs){
+    return *this = *this ^ rhs;
+}
+
+integer integer::operator~() const {
+    // in case value is 0
+    if (_value.empty()){
+        return 1;
+    }
+
+    integer::REP out = _value;
+
+    // invert whole digits
+    for(integer::REP_SIZE_T i = 1; i < out.size(); i++){
+        out[i] ^= integer::NEG1;
+    }
+
+    INTEGER_DIGIT_T mask = HIGH_BIT;
+    while (!(out[0] & mask)){
+        mask >>= 1;
+    }
+
+    // invert bits of partial digit
+    while (mask){
+        out[0] ^= mask;
+        mask >>= 1;
+    }
+
+    return integer(out, _sign);
+}
+
+// Bit Shift Operators
+
+// left bit shift. sign is maintained
+integer integer::operator<<(const integer & shift) const {
+    if (!*this || !shift){
+        return *this;
+    }
+
+    if (shift < 0){
+        throw std::runtime_error("Error: Negative shift amount");
+    }
+
+    const std::pair <integer, integer> qr = dm(shift, integer::BITS);
+    const integer & whole      = qr.first;             // number of zeros to add to the back
+    const INTEGER_DIGIT_T push = qr.second;            // push left by this many bits
+    const INTEGER_DIGIT_T pull = integer::BITS - push; // pull "push" bits from the right
+
+    integer::REP out = _value;
+
+    out.push_front(0);                                 // extra digit for shifting into
+    out.push_back(0);                                  // extra digit for shifting from
+
+    // do this part first to avoid shifting zeros
+    for(integer::REP_SIZE_T i = 0; i < (out.size() - 1); i++){
+        INTEGER_DOUBLE_DIGIT_T d = out[i];
+        d = (d << push) | (out[i + 1] >> pull);
+        out[i] = d & NEG1;
+        // out[i] = (out[i] << push) | (out[i + 1] >> pull);
+    }
+
+    if (!out[0]){                                      // if the top digit is still 0
+        out.pop_front();                               // remove it
+    }
+
+    if (!whole){                                       // if there was no need for the 0 at the end
+        out.pop_back();                                // remove it
+    }
+    else{
+        // push back zeros, excluding the one already there
+        out.insert(out.end(), whole - 1, 0);
+    }
+
+    return integer(out, _sign);
+}
+
+integer & integer::operator<<=(const integer & shift){
+    return *this = *this << integer(shift);
+}
+
+// right bit shift. sign is maintained
+integer integer::operator>>(const integer & shift) const {
+    if (shift < 0){
+        throw std::runtime_error("Error: Negative shift amount");
+    }
+
+    if (shift >= bits()){
+        return 0;
+    }
+
+    const std::pair <integer, integer> qr = dm(shift, integer::BITS);
+    const integer & whole      = qr.first;             // number of digits to pop off
+    const INTEGER_DIGIT_T push = qr.second;            // push right by this many bits
+    const INTEGER_DIGIT_T pull = integer::BITS - push; // pull "push" bits from the left
+
+    integer::REP out = _value;
+
+    // pop off whole digits
+    for(integer i = 0; i < whole; i++){
+        out.pop_back();
+    }
+
+    if (push){
+        out.push_front(0);                             // extra 0 for shifting from
+        for(integer::REP_SIZE_T i = 1; i < out.size(); i++){
+            out[out.size() - i] = (out[out.size() - i - 1] << pull) | (out[out.size() - i] >> push);
+        }
+        out.pop_front();
+    }
+
+    return integer(out, _sign);
+}
+
+integer & integer::operator>>=(const integer & shift){
+    return *this = *this >> integer(shift);
+}
+
+// Logical Operators
+bool integer::operator!(){
+    return !static_cast <bool> (*this);
+}
+
+// Comparison Operators
+bool integer::operator==(const integer & rhs) const {
+    return ((_sign == rhs._sign) && (_value == rhs._value));
+}
+
+bool integer::operator!=(const integer & rhs) const {
+    return !(*this == rhs);
+}
+
+// operator> not considering signs
+bool integer::gt(const integer & lhs, const integer & rhs) const {
+    if (lhs._value.size() > rhs._value.size()){
+        return true;
+    }
+    if (lhs._value.size() < rhs._value.size()){
+        return false;
+    }
+    if (lhs._value == rhs._value){
+        return false;
+    }
+    for(integer::REP_SIZE_T i = 0; i < lhs._value.size(); i++){
+        if (lhs._value[i] != rhs._value[i]){
+            return lhs._value[i] > rhs._value[i];
+        }
+    }
+    return false;
+}
+
+bool integer::operator>(const integer & rhs) const {
+    if      (    (_sign == integer::NEGATIVE) &&    // - > +
+             (rhs._sign == integer::POSITIVE)){
+        return false;
+    }
+    else if (   (_sign == integer::POSITIVE) &&     // + > -
+            (rhs._sign == integer::NEGATIVE)){
+        return true;
+    }
+    else if (   (_sign == integer::NEGATIVE) &&     // - > -
+            (rhs._sign == integer::NEGATIVE)){
+        return gt(rhs, *this);
+    }
+    // else if (    (_sign == integer::POSITIVE) && // + > +
+            //  (rhs._sign == integer::POSITIVE)){
+    return gt(*this, rhs);
+}
+
+bool integer::operator>=(const integer & rhs) const {
+    return ((*this > rhs) | (*this == rhs));
+}
+
+// operator< not considering signs
+bool integer::lt(const integer & lhs, const integer & rhs) const {
+    if (lhs._value.size() < rhs._value.size()){
+        return true;
+    }
+    if (lhs._value.size() > rhs._value.size()){
+        return false;
+    }
+    if (lhs._value == rhs._value){
+        return false;
+    }
+    for(integer::REP_SIZE_T i = 0; i < lhs._value.size(); i++){
+        if (lhs._value[i] != rhs._value[i]){
+            return lhs._value[i] < rhs._value[i];
+        }
+    }
+    return false;
+}
+
+bool integer::operator<(const integer & rhs) const {
+    if      (    (_sign == integer::NEGATIVE) &&     // - < +
+             (rhs._sign == integer::POSITIVE)){
+        return true;
+    }
+    else if (    (_sign == integer::POSITIVE) &&     // + < -
+             (rhs._sign == integer::NEGATIVE)){
+        return false;
+    }
+    else if (    (_sign == integer::NEGATIVE) &&     // - < -
+             (rhs._sign == integer::NEGATIVE)){
+        return lt(rhs, *this);
+    }
+    // else if (    (_sign == integer::POSITIVE) &&  // + < +
+            //  (rhs._sign == integer::POSITIVE)){
+    return lt(*this, rhs);
+}
+
+bool integer::operator<=(const integer & rhs) const {
+    return ((*this < rhs) | (*this == rhs));
+}
+
+// Arithmetic Operators
+integer integer::add(const integer & lhs, const integer & rhs) const {
+    integer::REP out;
+    integer::REP::const_reverse_iterator i = lhs._value.rbegin(), j = rhs._value.rbegin();
+    bool carry = false;
+    INTEGER_DOUBLE_DIGIT_T sum;
+
+    // add up matching digits
+    for(; ((i != lhs._value.rend()) && (j != rhs._value.rend())); i++, j++){
+        sum = static_cast <INTEGER_DOUBLE_DIGIT_T> (*i) + static_cast <INTEGER_DOUBLE_DIGIT_T> (*j) + carry;
+        out.push_front(sum);
+        carry = (sum > integer::NEG1);
+    }
+
+    // copy in lhs extra digits
+    for(; i != lhs._value.rend(); i++){
+        sum = static_cast <INTEGER_DOUBLE_DIGIT_T> (*i) + carry;
+        out.push_front(sum);
+        carry = (sum > integer::NEG1);
+    }
+
+    // copy in rhs extra digits
+    for(; j != rhs._value.rend(); j++){
+        sum = static_cast <INTEGER_DOUBLE_DIGIT_T> (*j) + carry;
+        out.push_front(sum);
+        carry = (sum > integer::NEG1);
+    }
+
+    if (carry){
+        out.push_front(1);
+    }
+    return integer(out);
+}
+
+integer integer::operator+(const integer & rhs) const {
+    if (!rhs){
+        return *this;
+    }
+
+    if (!*this){
+        return rhs;
+    }
+
+    integer out = *this;
+    if (gt(out, rhs)){              // lhs > rhs
+        if (_sign == rhs._sign){    // same sign: lhs + rhs
+            out = add(out, rhs);
+        }
+        else{                       // different signs: lhs - rhs
+            out = sub(out, rhs);
+        }
+        out._sign = _sign;          // lhs sign dominates
+    }
+    else if (lt(out, rhs)){         // lhs < rhs
+        if (_sign == rhs._sign){    // same sign: rhs + lhs
+            out = add(rhs, out);
+        }
+        else{                       // different sign: rhs - lhs
+            out = sub(rhs, out);
+        }
+        out._sign = rhs._sign;      // rhs sign dominates
+    }
+    else{                           // lhs == rhs
+        if (_sign == rhs._sign){    // same sign: double value
+            out <<= 1;
+            out._sign = _sign;
+        }
+        else{                       // different signs: 0
+            return 0;
+        }
+    }
+    out.trim();
+    return out;
+}
+
+integer & integer::operator+=(const integer & rhs){
+    return *this = *this + rhs;
+}
+
+// Subtraction as done by hand
+integer integer::long_sub(const integer & lhs, const integer & rhs) const {
+    // rhs always smaller than lhs
+    integer out = lhs;
+    integer::REP_SIZE_T lsize = out._value.size() - 1;
+    integer::REP_SIZE_T rsize = rhs._value.size() - 1;
+
+    for(integer::REP_SIZE_T x = 0; x <= rsize; x++){
+        // if top is bigger than or equal to the bottom, just substract
+        if (out._value[lsize - x] >= rhs._value[rsize - x]){
+            out._value[lsize - x] -= rhs._value[rsize - x];
+        }
+        else{// find a higher digit to carry from
+            integer::REP_SIZE_T y = lsize - x - 1;
+            // if this goes out of bounds, something is wrong
+            while (!out._value[y]){
+                y--;
+            }
+
+            out._value[y]--;
+            y++;
+
+            for(; y < lsize - x; y++){
+                out._value[y] = integer::NEG1;
+            }
+
+            out._value[y] = static_cast <INTEGER_DOUBLE_DIGIT_T> (out._value[y]) + (static_cast <uint64_t> (1) << integer::BITS) - rhs._value[rsize - x];
+        }
+    }
+    return out;
+}
+
+//// Two's Complement Subtraction
+//integer integer::two_comp_sub(const integer & lhs, const integer & rhs){
+//    rhs = rhs.twos_complement(lhs.bits());
+//    return add(lhs, rhs) & (~(integer(1) << lhs.bits()));   // Flip bits to get max of 1 << x
+//}
+
+// subtraction not considering signs
+// lhs must be larger than rhs
+integer integer::sub(const integer & lhs, const integer & rhs) const {
+    if (!rhs){
+        return lhs;
+    }
+    if (!lhs){
+        return -rhs;
+    }
+    if (lhs == rhs){
+        return 0;
+    }
+    return long_sub(lhs, rhs);
+    // return two_comp_sub(lhs, rhs);
+}
+
+integer integer::operator-(const integer & rhs) const {
+    integer out = *this;
+    if (gt(out, rhs)){                                  // if lhs > rhs
+        if (out._sign == rhs._sign){                    // same signs
+            out = sub(out, rhs);
+        }
+        else if (out._sign != rhs._sign){               // different signs
+            out = add(out, rhs);
+        }
+        out._sign = _sign;                              // lhs sign dominates
+    }
+    else if (lt(out, rhs)){                             // if lhs < rhs
+        if      (    (_sign == integer::NEGATIVE) &&    // - - -
+                 (rhs._sign == integer::NEGATIVE)){
+            out = sub(rhs, out);
+            out._sign = integer::POSITIVE;
+        }
+        else if (    (_sign == integer::NEGATIVE) &&    // - - +
+                 (rhs._sign == integer::POSITIVE)){
+            out = add(rhs, out);
+            out._sign = integer::NEGATIVE;
+        }
+        else if (    (_sign == integer::POSITIVE) &&    // + - -
+                 (rhs._sign == integer::NEGATIVE)){
+            out = add(out, rhs);
+            out._sign = integer::POSITIVE;
+        }
+        else if (    (_sign == integer::POSITIVE) &&    // + - +
+                 (rhs._sign == integer::POSITIVE)){
+            out = sub(rhs, out);
+            out._sign = integer::NEGATIVE;
+        }
+    }
+    else{                                               // if lhs == rhs
+        if (_sign == rhs._sign){                        // same signs: 0
+            return 0;
+        }
+        else{                                           // different signs: double value
+            out <<= 1;
+            out._sign = _sign;
+        }
+    }
+    out.trim();
+    return out;
+}
+
+integer & integer::operator-=(const integer & rhs){
+    return *this = *this - rhs;
+}
+
+// // Peasant Multiplication
+// integer integer::peasant(const integer & lhs, const integer & rhs) const {
+   // integer rhs_copy = rhs;
+   // integer sum = 0;
+   // for(integer::REP_SIZE_T x = 0; x < lhs.bits(); x++){
+      // if (lhs[x]){
+          // sum += add(sum, rhs_copy);
+       // }
+      // rhs_copy <<= 1;
+   // }
+   // return sum;
+// }
+
+// // Recurseive Peasant Algorithm
+// integer integer::recursive_peasant(const integer & lhs, const integer & rhs) const {
+   // if (!rhs){
+       // return 0;
+   // }
+   // if (rhs & 1){
+       // return lhs + recursive_peasant(lhs << 1, rhs >> 1);
+   // }
+   // return recursive_peasant(lhs << 1, rhs >> 1);
+// }
+
+// // Recursive Multiplication
+// integer integer::recursive_mult(const integer & lhs, const integer & rhs) const {
+   // if (!rhs){
+      // return 0;
+   // }
+   // integer z = recursive_mult(lhs, rhs >> 1);
+   // if (!(rhs & 1)){
+      // return z << 1;
+   // }
+   // return add(lhs, z << 1);
+// }
+
+// // Karatsuba Algorithm
+// integer integer::karatsuba(const integer & lhs, const integer & rhs, integer bm) const {
+  // // b is integer::REP = 256
+  // // m is chars = 4
+  // // bm is max _value = b ^ m
+
+  // if ((lhs <= bm) | (rhs <= bm))
+      // return peasant(lhs, rhs);
+
+  // std::pair <integer, integer> x = dm(lhs, bm);
+  // std::pair <integer, integer> y = dm(rhs, bm);
+  // integer x0 = x.second;
+  // integer x1 = x.first;
+  // integer y0 = y.second;
+  // integer y1 = y.first;
+
+  // integer z0 = karatsuba(x0, y0);
+  // integer z2 = karatsuba(x1, y1);
+  // integer z1 = sub(sub(karatsuba(add(x1, x0), add(y1, y0)), z2), z0);
+  // return add(karatsuba(add(karatsuba(z2, bm), z1), bm), z0);
+// }
+
+// // Toom-Cook multiplication
+// // as described at http://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplications
+// // This implementation is a bit weird. In the pointwise Multiplcation step, using
+// // operator* and long_mult works, but everything else fails.
+// // It's also kind of slow.
+// integer integer::toom_cook_3(integer m, integer n, integer bm){
+  // if ((m <= bm) | (n <= bm)){
+      // return peasant(m, n);
+   // }
+
+  // // Splitting
+  // integer i = integer(std::max(m.log(3), n.log(3))) / 3 + 1;
+  // integer bi = pow(integer(3), i);
+  // integer B = 1;
+  // integer integer::REP = 10;
+  // while (B < bi){
+      // B *= integer::REP;
+   // }
+
+  // integer M[3], N[3];
+  // for(uint8_t i = 0; i < 3; i++){
+      // std::pair <integer, integer> tm = dm(m, B);
+      // std::pair <integer, integer> tn = dm(n, B);
+      // m = tm.first;
+      // n = tn.first;
+      // M[i] = tm.second;
+      // N[i] = tn.second;
+  // }
+
+  // // Evaluation
+  // //             {0,             1,                 -1,                         -2,                             inf}
+  // integer p[5] = {M[0], M[0] + M[1] + M[2], M[0] - M[1] + M[2], M[0] - M[1] - M[1] + M[2] + M[2] + M[2] + M[2], M[2]};
+  // integer q[5] = {N[0], N[0] + N[1] + N[2], N[0] - N[1] + N[2], N[0] - N[1] - N[1] + N[2] + N[2] + N[2] + N[2], N[2]};
+
+  // // Pointwise Multiplication
+  // integer r[5];
+  // for(uint8_t i = 0; i < 5; i++)
+      // r[i] = p[i] * q[i];                 // don't understand why only integer::operator* and long_mult can be used here
+
+  // // Interpolation
+  // integer r0 = r[0];
+  // integer r4 = r[4];
+  // integer r3 = (r[3] - r[1]) / 3;
+  // integer r1 = (r[1] - r[2]) / 2;
+  // integer r2 = r[2] - r[0];
+  // r3 = (r2 - r3) / 2 + r4 + r4;
+  // r2 = r2 + r1 - r4;
+  // r1 = r1 - r3;
+
+  // // Recomposition
+  // return peasant(peasant(peasant(peasant(r4, B) + r3, B) + r2, B) + r1, B) + r0;
+// }
+
+// // Long multiplication
+// integer integer::long_mult(const integer & lhs, const integer & rhs) const {
+   // unsigned int zeros = 0;
+   // integer row, out = 0;
+   // for(integer::REP::const_reverse_iterator i = lhs._value.rbegin(); i != lhs._value.rend(); i++){
+       // row._value = integer::REP(zeros++, 0); // zeros on the right hand side
+       // INTEGER_DIGIT_T carry = 0;
+       // for(integer::REP::const_reverse_iterator j = rhs._value.rbegin(); j != rhs._value.rend(); j++){
+           // INTEGER_DOUBLE_DIGIT_T prod = (INTEGER_DOUBLE_DIGIT_T) *i * (INTEGER_DOUBLE_DIGIT_T) *j + carry;// multiply through
+           // row._value.push_front(prod & integer::NEG1);
+           // carry = prod >> integer::BITS;
+       // }
+       // if (carry){
+           // row._value.push_front(carry);
+       // }
+       // out = add(out, row);
+   // }
+   // return out;
+// }
+
+//Private FFT helper function
+int integer::fft(std::deque<double>& data, bool dir) const
+{
+     //Verify size is a power of two
+     std::size_t n = data.size()/2;
+     if ((n == 0) || (n & (n-1))) return 1;
+
+     //rearrange data for signal flow chart
+     std::size_t bitr_j = 1;
+     for (std::size_t i = 3; i < 2*n-1; i += 2)
+     {
+          std::size_t msz = n;
+          while (bitr_j >= msz)
+          {
+               bitr_j -= msz;
+               msz >>= 1;
+          }
+          bitr_j += msz;
+
+          if (bitr_j > i)
+          {
+               double swap = data[bitr_j-1];
+               data[bitr_j-1] = data[i-1];
+               data[i-1] = swap;
+               swap = data[bitr_j];
+               data[bitr_j] = data[i];
+               data[i] = swap;
+          }
+     }
+
+     //Perform "butterfly" calculations
+     std::size_t lmax = 2;
+     while (lmax <= n)
+     {
+          double wr = 1;
+          double wi = 0;
+
+          double theta = (2*M_PI)/double(lmax*(dir?1.0:-1.0));
+          double wpr = cos(theta);
+          double wpi = sin(theta);
+
+          int pstep = 2*lmax;
+          for (std::size_t l = 1; l < lmax; l += 2)
+          {
+               for (std::size_t p = l; p < 2*n; p += pstep)
+               {
+                    std::size_t q = p + lmax;
+                    double tempr = wr*data[q-1] - wi*data[q];
+                    double tempi = wr*data[q] + wi*data[q-1];
+                    data[q-1] = data[p-1] - tempr;
+                    data[q] = data[p] - tempi;
+                    data[p-1] = data[p-1] + tempr;
+                    data[p] = data[p] + tempi;
+               }
+
+               //Find the next power of W
+               double wtemp = wr;
+               wr = wr*wpr - wi*wpi;
+               wi = wi*wpr + wtemp*wpi;
+          }
+
+          lmax = pstep;
+     }
+
+     //All is good
+     return 0;
+}
+
+// FFT-based multiplication
+//Based on the convolution theorem which states that the Fourier
+//transform of a convolution is the pointwise product of their
+//Fourier transforms.
+integer integer::fft_mult(const integer& lhs, const integer& rhs) const {
+     //Convert each integer to input wanted by fft()
+     size_t size = 1;
+     while (size < lhs._value.size()*2){
+          size <<= 1;
+     }
+     while (size < rhs._value.size()*2){
+          size <<= 1;
+     }
+
+     std::deque<double> lhs_fft;
+     lhs_fft.resize(size*2, 0);
+     for (size_t i = 0; i < lhs._value.size(); i++){
+          lhs_fft[i*2] = double(lhs._value[lhs._value.size()-1-i]);
+     }
+
+     std::deque<double> rhs_fft;
+     rhs_fft.resize(size*2, 0);
+     for (size_t i = 0; i < rhs._value.size(); i++){
+          rhs_fft[i*2] = double(rhs._value[rhs._value.size()-1-i]);
+     }
+
+     //Compute the FFT of each
+     fft(lhs_fft);
+     fft(rhs_fft);
+
+     //Perform pointwise multiplication (numbers are complex)
+     std::deque<double> out_fft(2*size);
+     for (size_t i = 0; i < 2*size; i+=2){
+          out_fft[i] = lhs_fft[i]*rhs_fft[i] - lhs_fft[i+1]*rhs_fft[i+1];
+          out_fft[i+1] = lhs_fft[i]*rhs_fft[i+1] + lhs_fft[i+1]*rhs_fft[i];
+     }
+
+     //Compute the inverse FFT of this number
+     //remember to properly scale afterwards!
+     fft(out_fft, false);
+     for (size_t i = 0; i < 2*size; i++){
+          out_fft[i] /= size;
+     }
+
+     //Convert back to integer, carrying along the way
+     double carry = 0;
+     integer out;
+     for (size_t i = 0; i < 2*size; i+=2){
+          double current = out_fft[i]+carry;
+          if (current > double(integer::NEG1)){
+               carry = current / (double(integer::NEG1)+1);
+               carry = double(floor(carry+0.0001));
+               current = current - (carry*(integer::NEG1+1));
+
+          }
+          else {
+               carry = 0;
+          }
+          out._value.push_front(INTEGER_DIGIT_T(current+0.0001));
+     }
+
+     //Finish up
+     return out;
+}
+
+integer integer::operator*(const integer & rhs) const {
+    // quick checks
+    if (!*this || !rhs){    // if multiplying by 0
+        return 0;
+    }
+    if (*this == 1){        // if multiplying by 1
+        return rhs;
+    }
+    if (rhs == 1){          // if multiplying by 1
+        return *this;
+    }
+
+    // integer out = peasant(*this, rhs);
+    // integer out = recursive_peasant(*this, rhs);
+    // integer out = recursive_mult(*this, rhs);
+    // integer out = karatsuba(*this, rhs);
+    // integer out = toom_cook_3(*this, rhs);
+    // integer out = long_mult(*this, rhs);
+    integer out = fft_mult(*this, rhs);
+    out._sign = _sign ^ rhs._sign;
+    out.trim();
+    return out;
+}
+
+integer & integer::operator*=(const integer & rhs){
+    return *this = *this * rhs;
+}
+
+// // Naive Division: keep subtracting until lhs == 0
+// std::pair <integer, integer> integer::naive_divmod(const integer & lhs, const integer & rhs) const {
+    // std::pair <integer, integer> qr (0, lhs);
+    // while (qr.second >= rhs){
+        // qr.second -= rhs;
+        // qr.first++;
+    // }
+    // return qr;
+// }
+
+// // Long Division returning both quotient and remainder
+// std::pair <integer, integer> integer::long_divmod(const integer & lhs, const integer & rhs) const {
+   // std::pair <integer, integer> qr(0, lhs);
+   // integer copyd = rhs;
+   // integer adder = 1;
+   // integer shift = qr.second.bits() - copyd.bits();
+    // copyd <<= shift;
+    // adder <<= shift;
+   // // while (qr.second > copyd){
+       // // copyd <<= 1;
+       // // adder <<= 1;
+   // // }
+   // while (qr.second >= rhs){
+       // if (qr.second >= copyd){
+           // qr.second -= copyd;
+           // qr.first |= adder;
+       // }
+       // copyd >>= 1;
+       // adder >>= 1;
+   // }
+   // return qr;
+// }
+
+// // Recursive Division that returns both the quotient and remainder
+// // Recursion took up way too much memory
+// std::pair <integer, integer> integer::recursive_divmod(const integer & lhs, const integer & rhs) const {
+   // std::pair <integer, integer> qr;
+   // if (!lhs){
+       // qr.first = 0;
+       // qr.second = 0;
+       // return qr;
+   // }
+   // qr = recursive_divmod(lhs >> 1, rhs);
+   // qr.first <<= 1;
+   // qr.second <<= 1;
+   // if (lhs & 1)
+       // qr.second++;
+   // if (qr.second >= rhs){
+       // qr.second -= rhs;
+       // qr.first++;
+   // }
+   // return qr;
+// }
+
+// Non-Recursive version of above algorithm
+std::pair <integer, integer> integer::non_recursive_divmod(const integer & lhs, const integer & rhs) const {
+    std::pair <integer, integer> qr (0, 0);
+    for(integer::REP_SIZE_T x = lhs.bits(); x > 0; x--){
+        qr.first  <<= 1;
+        qr.second <<= 1;
+
+        if (lhs[x - 1]){
+            qr.second++;
+        }
+
+        if (qr.second >= rhs){
+            qr.second -= rhs;
+            qr.first++;
+        }
+    }
+    return qr;
+}
+
+// division and modulus ignoring signs
+std::pair <integer, integer> integer::dm(const integer & lhs, const integer & rhs) const {
+    if (!rhs){              // divide by 0 error
+        throw std::domain_error("Error: division or modulus by 0");
+    }
+
+    if (rhs == 1){          // divide by 1 check
+        return {lhs, 0};
+    }
+    if (lhs == rhs){        // divide by same value check
+        return {1, 0};
+    }
+    if (!lhs){              // 0 / rhs check
+        return {0, 0};
+    }
+    if (lt(lhs, rhs)){      // lhs < rhs check
+        return {0, lhs};
+    }
+
+    // return naive_divmod(lhs, rhs);
+    // return long_divmod(lhs, rhs);
+    // return recursive_divmod(lhs, rhs);
+    return non_recursive_divmod(lhs, rhs);
+}
+
+// division and modulus with signs
+std::pair <integer, integer> integer::divmod(const integer & lhs, const integer & rhs) const {
+    std::pair <integer, integer> out = dm(abs(lhs), abs(rhs));
+    out.first._sign = lhs._sign ^ rhs._sign;
+
+    if (lhs._sign == integer::NEGATIVE){
+        out.second = -out.second;
+    }
+
+    // if      ((lhs._sign == integer::POSITIVE) &&    // + % +
+             // (rhs._sign == integer::POSITIVE)){
+        // // out.second = out.second;
+    // }
+    // else if ((lhs._sign == integer::POSITIVE) &&    // + % -
+             // (rhs._sign == integer::NEGATIVE)){
+        // // out.second = out.second;
+    // }
+    // else if ((lhs._sign == integer::NEGATIVE) &&    // - % +
+             // (rhs._sign == integer::POSITIVE)){
+        // out.second = -out.second;
+    // }
+    // else if ((lhs._sign == integer::NEGATIVE) &&    // - % -
+             // (rhs._sign == integer::NEGATIVE)){
+        // out.second = -out.second;
+    // }
+
+    return out;
+}
+
+integer integer::operator/(const integer & rhs) const {
+    return divmod(*this, rhs).first;
+}
+
+integer & integer::operator/=(const integer & rhs){
+    return *this = *this / integer(rhs);
+}
+
+integer integer::operator%(const integer & rhs) const {
+    return divmod(*this, rhs).second;
+}
+
+integer & integer::operator%=(const integer & rhs){
+    return *this = *this % rhs;
+}
+
+// Prefix ++
+integer & integer::operator++(){
+    return *this += 1;
+}
+
+// Postfix ++
+integer integer::operator++(int){
+    integer temp(*this);
+    ++*this;
+    return temp;
+}
+
+// Prefix --
+integer & integer::operator--(){
+    return *this -= 1;
+}
+
+// Postfix --
+integer integer::operator--(int){
+    integer temp(*this);
+    --*this;
+    return temp;
+}
+
+// Nothing done since promotion doesnt work here
+integer integer::operator+() const {
+    return *this;
+}
+
+// Flip Sign
+integer integer::operator-() const {
+    return integer(_value, !_sign);
+}
+
+// get private values
+integer::Sign integer::sign() const {
+    return _sign;
+}
+
+// get minimum number of bits needed to hold this value
+integer integer::bits() const {
+    integer         out = integer(_value.empty()?0:(_value.size() - 1)) * integer::BITS;
+    INTEGER_DIGIT_T msb = _value.empty()?0:_value[0];
+    while (msb){
+        msb >>= 1;
+        out++;
+    }
+
+    return out;
+}
+
+// get minimum number of bytes needed to hold this value
+integer::REP_SIZE_T integer::bytes() const {
+    integer::REP_SIZE_T out = (_value.empty()?0:(_value.size() - 1)) * integer::OCTETS;
+    INTEGER_DIGIT_T     msb = (_value.empty()?0:_value[0]);
+    while (msb){
+        msb >>= 8;
+        out++;
+    }
+
+    return out;
+}
+
+// get number of digits
+integer::REP_SIZE_T integer::digits() const {
+    return _value.size();
+}
+
+// get internal data
+integer::REP integer::data() const {
+    return _value;
+}
+
+// Miscellaneous Functions
+integer & integer::negate(){
+    _sign = !_sign;
+    return trim();
+}
+
+integer integer::twos_complement(const integer::REP_SIZE_T & b) const {
+    integer mask; mask.fill(b);
+    integer out = ((abs(*this) ^ mask) + 1) & mask;
+    out._sign = !_sign;
+    return out.trim();
+}
+
+// fills an integer with 1s
+integer & integer::fill(const integer::REP_SIZE_T & b){
+    _value = integer::REP(b / integer::BITS, integer::NEG1);
+    if (b % integer::BITS){
+        _value.push_front((1 << (b % integer::BITS)) - 1);
+    }
+    return *this;
+}
+
+// get bit, where 0 is the lsb and bits() - 1 is the msb
+bool integer::operator[](const integer::REP_SIZE_T & b) const {
+    if (b >= bits()){ // if given index is larger than bits in this _value, return 0
+        return 0;
+    }
+    return (_value[_value.size() - (b / integer::BITS) - 1] >> (b % integer::BITS)) & 1;
+}
+
+// Output value as a string from base 2 to 16, or base 256
+std::string integer::str(const integer & base, const std::string::size_type & length) const {
+    std::string out = "";
+    if ((2 <= base) && (base <= 16)){
+        static const std::string digits = "0123456789abcdef";
+        integer rhs = abs(*this);       // use absolute value to make sure index stays small
+        if (*this == 0){
+            out = "0";
+        }
+        else{
+            std::pair <integer, integer> qr;
+            do{
+                qr = dm(rhs, base);
+                out = digits[qr.second] + out;
+                rhs = qr.first;
+            } while (rhs);
+        }
+
+        // pad with '0's
+        if (out.size() < length){
+            out = std::string(length - out.size(), '0') + out;
+        }
+    }
+    else if (base == 256){
+        if (_value.empty()){
+            out = std::string(1, 0);
+        }
+        else{
+            // for each digit
+            for(INTEGER_DIGIT_T const & d : _value){
+                // write out each character
+                for(std::size_t i = integer::OCTETS << 3; i > 0; i -= 8){
+                    out += std::string(1, (d >> (i - 8)) & 0xff);
+                }
+            }
+
+            // remove leading '\x00's
+            // this is possible because _value is being read
+            // one character at a time, not one byte at a time
+            if (out.size() > length){
+                std::size_t i = 0;
+                while ((i < out.size()) && !out[i]){
+                    i++;
+                }
+
+                out = out.substr(i, out.size() - i);
+            }
+        }
+
+        // pad with '\x00's
+        if (out.size() < length){
+            out = std::string(length - out.size(), '\x00') + out;
+        }
+    }
+    else{
+        throw std::runtime_error("Error: Cannot convert to base " + base.str(10));
+    }
+
+    // if value is negative, add a minus sign in front
+    // no special case for leading zeros/nulls
+    if (_sign == integer::NEGATIVE){
+        out = "-" + out;
+    }
+
+    return out;
+}
+
+// Bitshift Operators
+integer operator<<(const bool & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const uint8_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const uint16_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const uint32_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const uint64_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const int8_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const int16_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const int32_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator<<(const int64_t & lhs, const integer & rhs){
+    return integer(lhs) << rhs;
+}
+
+integer operator>>(const bool & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const uint8_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const uint16_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const uint32_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const uint64_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const int8_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const int16_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const int32_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+integer operator>>(const int64_t & lhs, const integer & rhs){
+    return integer(lhs) >> rhs;
+}
+
+// IO Operators
+std::ostream & operator<<(std::ostream & stream, const integer & rhs){
+    if (stream.flags() & stream.oct){
+        stream << rhs.str(8);
+    }
+    else if (stream.flags() & stream.hex){
+        stream << rhs.str(16);
+    }
+    else{
+        stream << rhs.str(10);
+    }
+    return stream;
+}
+
+std::istream & operator>>(std::istream & stream, integer & rhs){
+    uint8_t base;
+    if (stream.flags() & stream.oct){
+        base = 8;
+    }
+    else if (stream.flags() & stream.hex){
+        base = 16;
+    }
+    else{
+        base = 10;
+    }
+    std::string in;
+    stream >> in;
+    rhs = integer(in, base);
+    return stream;
+}
+
+// Special functions
+std::string makebin(const integer & value, const unsigned int & size){
+    // Changes a value into its binary string
+    return value.str(2, size);
+}
+
+std::string makehex(const integer & value, const unsigned int & size){
+    // Changes a value into its hexadecimal string
+    return value.str(16, size);
+}
+
+std::string makeascii(const integer & value, const unsigned int & size){
+    // Changes a value into ASCII
+    return value.str(256, size);
+}
+
+integer abs(const integer & value){
+    return (value.sign() == integer::POSITIVE)?value:-value;
+}

--- a/external/bigint/integer.h
+++ b/external/bigint/integer.h
@@ -1,0 +1,811 @@
+/*
+integer.h
+
+Copyright (c) 2013 - 2017 Jason Lee @ calccrypto at gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <cmath> //For fft sin, cos, M_PI, and floor
+#include <cstdint>
+#include <deque>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <type_traits>
+
+#include <sstream>
+
+#ifndef M_PI
+#define M_PI 3.14159265359
+#endif
+
+#ifndef __INTEGER__
+#define __INTEGER__
+
+#ifndef INTEGER_DIGIT_T
+#define INTEGER_DIGIT_T        uint8_t
+#endif
+
+#ifndef INTEGER_DOUBLE_DIGIT_T
+#define INTEGER_DOUBLE_DIGIT_T uint64_t
+#endif
+
+// INTEGET_DIGIT_T and INTEGER_DOUBLE_DIGIT_T
+// should be unsigned integers
+static_assert(std::is_unsigned <INTEGER_DIGIT_T>::value &&
+              std::is_unsigned <INTEGER_DOUBLE_DIGIT_T>::value
+              , "Internal types must be unsigned integers");
+
+// INTEGER_DOUBLE_DIGIT_T should be at least 2 times the size of INTEGER_DIGIT_T
+static_assert((2 * sizeof(INTEGER_DIGIT_T)) <= sizeof(INTEGER_DOUBLE_DIGIT_T)
+              , "INTEGER_DOUBLE_DIGIT_T should be at least twice the size of INTEGER_DIGIT_T");
+
+class integer{
+    public:
+        typedef std::deque <INTEGER_DIGIT_T> REP;                                                 // internal representation of values
+        typedef REP::size_type               REP_SIZE_T;                                          // size type of internal representation
+
+    private:
+        static constexpr INTEGER_DIGIT_T NEG1     = std::numeric_limits <INTEGER_DIGIT_T>::max(); // value with all bits ON - will only work for unsigned integer types
+        static constexpr std::size_t     OCTETS   = sizeof(INTEGER_DIGIT_T);                      // number of octets per INTEGER_DIGIT_T
+        static constexpr std::size_t     BITS     = OCTETS << 3;                                  // number of bits per INTEGER_DIGIT_T; hardcode this if INTEGER_DIGIT_T is not standard int type
+        static constexpr INTEGER_DIGIT_T HIGH_BIT = 1 << (BITS - 1);                              // highest bit of INTEGER_DIGIT_T (uint8_t -> 128)
+
+    public:
+        typedef bool Sign;
+        static constexpr Sign POSITIVE = false;                                                   // includes 0
+        static constexpr Sign NEGATIVE = true;
+
+    private:
+        bool _sign;     // sign of value
+        REP _value;     // absolute value of *this
+
+        template <typename Z>
+        integer & setFromZ(Z val){
+            static_assert( std::is_integral  <Z>::value &&
+                          !std::is_const     <Z>::value &&
+                          !std::is_reference <Z>::value
+                          , "Input to integer::setFromZ should be passed by value");
+            _value.clear();
+            _sign = POSITIVE;
+
+            // make positive
+            if (std::is_signed <Z>::value && (val < 0)){
+                _sign = NEGATIVE;
+                val = -val; // treat as positive even if top bit is still set
+            }
+
+            // keep this here just in case value is sign extended
+            for(std::size_t d = std::max(sizeof(Z) / OCTETS, (std::size_t) 1); d > 0; d--){
+                _value.push_front(val & NEG1);
+                val >>= BITS;
+            }
+
+            return trim();
+        }
+
+        // remove 0 digits from top of deque to save memory
+        integer & trim();
+
+    public:
+        // Constructors
+        integer();
+        integer(const integer & rhs);
+        integer(integer && rhs);
+        integer(const REP & rhs, const Sign & sign = POSITIVE);
+
+        // Special boolean constructor
+        integer(const bool & b);
+
+        // Constructors for integral input
+        template <typename Z>
+        integer(const Z & val){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            setFromZ(val);
+        }
+
+        // Special Constructor for Strings
+        // bases 2-16 and 256 are allowed
+        //      Written by Corbin http://codereview.stackexchange.com/a/13452
+        //      Modified by me
+        integer(const std::string & val, const integer & base);
+
+        // Use this to construct integers with other types that have pointers/iterators to their beginning and end
+        // all inputs are treated as positive values
+        template <typename Iterator> integer(Iterator start, const Iterator & end, const integer & base) : integer()
+        {
+            if (base < 2){
+                throw std::runtime_error("Error: Cannot convert from base " + base.str(10));
+            }
+
+            for(; start != end; start++){
+                *this = (*this * base) | *start;
+            }
+        }
+
+    public:
+        //  RHS input args only
+
+        // Assignment Operator
+        integer & operator=(const integer & rhs);
+        integer & operator=(integer && rhs);
+        template <typename Z>
+        integer & operator=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            setFromZ(rhs);
+            return *this;
+        }
+
+        // Typecast Operators
+        operator bool()     const;
+        operator uint8_t()  const;
+        operator uint16_t() const;
+        operator uint32_t() const;
+        operator uint64_t() const;
+        operator int8_t()   const;
+        operator int16_t()  const;
+        operator int32_t()  const;
+        operator int64_t()  const;
+
+        // Bitwise Operators
+        integer operator&(const integer & rhs) const;
+        template <typename Z>
+        integer operator&(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this & integer(rhs);
+        }
+
+        integer & operator&=(const integer & rhs);
+        template <typename Z>
+        integer & operator&=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this &= integer(rhs);
+        }
+
+        integer operator|(const integer & rhs) const;
+        template <typename Z>
+        integer operator|(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this | integer(rhs);
+        }
+
+        integer & operator|=(const integer & rhs);
+        template <typename Z>
+        integer & operator|=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this |= integer(rhs);
+        }
+
+        integer operator^(const integer & rhs) const;
+        template <typename Z>
+        integer operator^(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this ^ integer(rhs);
+        }
+
+        integer & operator^=(const integer & rhs);
+        template <typename Z>
+        integer & operator^=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this ^= integer(rhs);
+        }
+
+        integer operator~() const;
+
+        // Bitshift Operators
+        // left bitshift. sign is maintained
+        integer operator<<(const integer & shift) const;
+        template <typename Z>
+        integer operator<<(const Z & rhs)         const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this << integer(rhs);
+        }
+
+        integer & operator<<=(const integer & shift);
+        template <typename Z>
+        integer & operator<<=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this <<= integer(rhs);
+        }
+
+        // right bitshift. sign is maintained
+        integer operator>>(const integer & shift) const;
+        template <typename Z>
+        integer operator>>(const Z & rhs)         const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this >> integer(rhs);
+        }
+
+        integer & operator>>=(const integer & shift);
+        template <typename Z>
+        integer & operator>>=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this >>= integer(rhs);
+        }
+
+        // Logical Operators
+        bool operator!();
+
+        // Comparison Operators
+        bool operator==(const integer & rhs) const;
+        template <typename Z>
+        integer operator==(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this == integer(rhs));
+        }
+
+        bool operator!=(const integer & rhs) const;
+        template <typename Z>
+        integer operator!=(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this != integer(rhs));
+        }
+
+    private:
+        // operator> not considering signs
+        bool gt(const integer & lhs, const integer & rhs) const;
+
+    public:
+        bool operator>(const integer & rhs) const;
+        template <typename Z>
+        integer operator>(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this > integer(rhs));
+        }
+
+        bool operator>=(const integer & rhs) const;
+        template <typename Z>
+        integer operator>=(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this >= integer(rhs));
+        }
+
+    private:
+        // operator< not considering signs
+        bool lt(const integer & lhs, const integer & rhs) const;
+
+    public:
+        bool operator<(const integer & rhs) const;
+        template <typename Z>
+        integer operator<(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this < integer(rhs));
+        }
+
+        bool operator<=(const integer & rhs) const;
+        template <typename Z>
+        integer operator<=(const Z & rhs)    const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return (*this <= integer(rhs));
+        }
+
+    private:
+        // Arithmetic Operators
+        integer add(const integer & lhs, const integer & rhs) const;
+
+    public:
+        integer operator+(const integer & rhs) const;
+        template <typename Z>
+        integer operator+(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this + integer(rhs);
+        }
+
+        integer & operator+=(const integer & rhs);
+        template <typename Z>
+        integer & operator+=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this += integer(rhs);
+        }
+
+    private:
+        // Subtraction as done by hand
+        // lhs must be larger than rhs
+        integer long_sub(const integer & lhs, const integer & rhs) const;
+
+        // // Two's Complement Subtraction
+        // integer two_comp_sub(const integer & lhs, const integer & rhs) const;
+
+        // subtraction not considering signs
+        // lhs must be larger than rhs
+        integer sub(const integer & lhs, const integer & rhs) const;
+
+    public:
+        integer operator-(const integer & rhs) const;
+        template <typename Z>
+        integer operator-(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this - integer(rhs);
+        }
+
+        integer & operator-=(const integer & rhs);
+        template <typename Z>
+        integer & operator-=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this -= integer(rhs);
+        }
+
+    private:
+        // // Peasant Multiplication
+        // integer peasant(const integer & lhs, const integer & rhs) const;
+
+        // // Recurseive Peasant Algorithm
+        // integer recursive_peasant(const integer & lhs, const integer & rhs) const;
+
+        // // Recursive Multiplication
+        // integer recursive_mult(const integer & lhs, const integer & rhs) const;
+
+        // // Karatsuba Algorithm O(n-log2(3) = n - 1.585)
+        // // The Peasant Multiplication function is needed if Karatsuba is used.
+        // // Thanks to kjo @ stackoverflow for fixing up my original Karatsuba Algorithm implementation
+        // // which I then converted to C++ and made a few changes.
+        // // http://stackoverflow.com/questions/7058838/karatsuba-algorithm-too-much-recursion
+        // integer karatsuba(const integer & lhs, const integer & rhs, integer bm = 0x1000000U) const;
+
+        // // // Toom-Cook multiplication
+        // // // as described at http://en.wikipedia.org/wiki/Toom%E2%80%93Cook_multiplications
+        // // // The peasant function is needed if karatsuba is used.
+        // // // This implementation is a bit weird. In the pointwise Multiplcation step, using
+        // // // operator* and long_mult works, but everything else fails.
+        // // // It's also kind of slow.
+        // // integer toom_cook_3(integer m, integer n, integer bm = 0x1000000U);
+
+        // // Long multiplication
+        // integer long_mult(const integer & lhs, const integer & rhs) const;
+
+        //Private FFT helper function
+        int fft(std::deque<double>& data, bool dir = true) const;
+
+        // FFT-based multiplication
+        //Based on the convolution theorem which states that the Fourier
+        //transform of a convolution is the pointwise product of their
+        //Fourier transforms.
+        integer fft_mult(const integer& lhs, const integer& rhs) const;
+
+    public:
+        integer operator*(const integer & rhs) const;
+        template <typename Z>
+        integer operator*(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this * integer(rhs);
+        }
+
+        integer & operator*=(const integer & rhs);
+        template <typename Z>
+        integer & operator*=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this *= integer(rhs);
+        }
+
+    private:
+        // // Naive Division: keep subtracting until lhs == 0
+        // std::pair <integer, integer> naive_divmod(const integer & lhs, const integer & rhs) const;
+
+        // // Long Division returning both quotient and remainder
+        // std::pair <integer, integer> long_divmod(const integer & lhs, const integer & rhs) const;
+
+        // // Recursive Division that returns both the quotient and remainder
+        // // Recursion took up way too much memory
+        // std::pair <integer, integer> recursive_divmod(const integer & lhs, const integer & rhs) const;
+
+        // Non-Recursive version of above algorithm
+        std::pair <integer, integer> non_recursive_divmod(const integer & lhs, const integer & rhs) const;
+
+        // division and modulus ignoring signs
+        std::pair <integer, integer> dm(const integer & lhs, const integer & rhs) const;
+
+    public:
+        // division and modulus with signs
+        std::pair <integer, integer> divmod(const integer & lhs, const integer & rhs) const;
+
+        integer operator/(const integer & rhs) const;
+        template <typename Z>
+        integer operator/(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this / integer(rhs);
+        }
+
+        integer & operator/=(const integer & rhs);
+        template <typename Z>
+        integer & operator/=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this /= integer(rhs);
+        }
+
+        integer operator%(const integer & rhs) const;
+        template <typename Z>
+        integer operator%(const Z & rhs)       const {
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this % integer(rhs);
+        }
+
+        integer & operator%=(const integer & rhs);
+        template <typename Z>
+        integer & operator%=(const Z & rhs){
+            static_assert(std::is_integral <Z>::value
+                          , "Input type must be integral");
+            return *this %= integer(rhs);
+        }
+
+        // Increment Operator
+        integer & operator++();
+        integer operator++(int);
+
+        // Decrement Operator
+        integer & operator--();
+        integer operator--(int);
+
+        // Nothing done since promotion doesn't work here
+        integer operator+() const;
+
+        // Flip Sign
+        integer operator-() const;
+
+        // get private values
+        Sign sign() const;
+
+        // get minimum number of bits needed to hold this value
+        integer bits() const;
+
+        // get minimum number of bytes needed to hold this value
+        REP_SIZE_T bytes() const;
+
+        // get number of digits of internal representation
+        REP_SIZE_T digits() const;
+
+        // get internal data
+        REP data() const;
+
+        // Miscellaneous Functions
+        integer & negate();
+
+        // Two's compliment - specify number of bits to make output make sense
+        integer twos_complement(const REP_SIZE_T & b) const;
+
+        // fills an integer with 1s
+        integer & fill(const REP_SIZE_T & b);
+
+        // get bit, where 0 is the lsb and bits() - 1 is the msb
+        bool operator[](const REP_SIZE_T & b) const;
+
+        // Output _value as a string in bases 2 to 16, and 256
+        std::string str(const integer & base = 10, const std::string::size_type & length = 1) const;
+};
+
+// Give integer type traits
+namespace std {  // This is probably not a good idea
+    template <> struct is_arithmetic <integer> : std::true_type {};
+    template <> struct is_integral   <integer> : std::true_type {};
+    template <> struct is_signed     <integer> : std::true_type {};
+};
+
+// operators where lhs is not of type integer
+
+// Bitwise Operators
+template <typename Z>
+integer operator&(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) & rhs;
+}
+
+template <typename Z>
+Z & operator&=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) & rhs);
+}
+
+template <typename Z>
+integer operator|(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) | rhs;
+}
+
+template <typename Z>
+Z & operator|=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) | rhs);
+}
+
+template <typename Z>
+integer operator^(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) ^ rhs;
+}
+
+template <typename Z>
+Z & operator^=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) ^ rhs);
+}
+
+// Bitshift operators
+integer operator<<(const bool     & lhs, const integer & rhs);
+integer operator<<(const uint8_t  & lhs, const integer & rhs);
+integer operator<<(const uint16_t & lhs, const integer & rhs);
+integer operator<<(const uint32_t & lhs, const integer & rhs);
+integer operator<<(const uint64_t & lhs, const integer & rhs);
+integer operator<<(const int8_t   & lhs, const integer & rhs);
+integer operator<<(const int16_t  & lhs, const integer & rhs);
+integer operator<<(const int32_t  & lhs, const integer & rhs);
+integer operator<<(const int64_t  & lhs, const integer & rhs);
+
+template <typename Z>
+Z & operator<<=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) << rhs);
+}
+
+integer operator>>(const bool     & lhs, const integer & rhs);
+integer operator>>(const uint8_t  & lhs, const integer & rhs);
+integer operator>>(const uint16_t & lhs, const integer & rhs);
+integer operator>>(const uint32_t & lhs, const integer & rhs);
+integer operator>>(const uint64_t & lhs, const integer & rhs);
+integer operator>>(const int8_t   & lhs, const integer & rhs);
+integer operator>>(const int16_t  & lhs, const integer & rhs);
+integer operator>>(const int32_t  & lhs, const integer & rhs);
+integer operator>>(const int64_t  & lhs, const integer & rhs);
+
+template <typename Z>
+Z & operator>>=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) >> rhs);
+}
+
+// Comparison Operators
+template <typename Z>
+bool operator==(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (integer(lhs) == rhs);
+}
+
+template <typename Z>
+bool operator!=(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (integer(lhs) != rhs);
+}
+
+template <typename Z>
+bool operator>(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (rhs < lhs);
+}
+
+template <typename Z>
+bool operator>=(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (rhs <= lhs);
+}
+
+template <typename Z>
+bool operator<(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (rhs > lhs);
+}
+
+template <typename Z>
+bool operator<=(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return (rhs >= lhs);
+}
+
+// Arithmetic Operators
+template <typename Z>
+integer operator+(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) + rhs;
+}
+
+template <typename Z>
+Z & operator+=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) + rhs);
+}
+
+template <typename Z>
+integer operator-(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) - rhs;
+}
+
+template <typename Z>
+Z & operator-=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) - rhs);
+}
+
+template <typename Z>
+integer operator*(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) * rhs;
+}
+
+template <typename Z>
+Z & operator*=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) * rhs);
+}
+
+template <typename Z>
+integer operator/(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) / rhs;
+}
+
+template <typename Z>
+Z & operator/=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) / rhs);
+}
+
+template <typename Z>
+integer operator%(const Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value
+                  , "Input type must be integral");
+    return integer(lhs) % rhs;
+}
+
+template <typename Z>
+Z & operator%=(Z & lhs, const integer & rhs){
+    static_assert(std::is_integral <Z>::value &&
+                 !std::is_const <Z>::value
+                  , "Input type must be integral");
+    return lhs = static_cast <Z> (integer(lhs) % rhs);
+}
+
+// IO Operators
+std::ostream & operator<<(std::ostream & stream, const integer & rhs);
+std::istream & operator>>(std::istream & stream, integer & rhs);
+
+// Miscellaneous functions
+std::string makebin  (const integer & value, const unsigned int & size = 1);
+std::string makehex  (const integer & value, const unsigned int & size = 1);
+std::string makeascii(const integer & value, const unsigned int & size = 1);
+
+integer abs(const integer & value);
+
+// floor(log_b(x))
+template <typename Z>
+integer log(integer value, Z base){
+    static_assert(std::is_integral <Z>::value
+                  , "Base type should be a non-negative integer");
+
+    if ((base < 1) || (value <= 0)){
+        throw std::domain_error("Error: Domain error");
+    }
+
+    integer count = 0;
+    while (value){
+        value /= base;
+        count++;
+    }
+    return count;
+}
+
+template <typename Z>
+integer pow(integer value, Z exp){
+    static_assert(std::is_integral <Z>::value
+                  , "Exponent type should be integral");
+
+    if (exp < 0){
+        return 0;
+    }
+
+    Z one = 1;
+    integer result = 1;
+    while (exp){
+        if (exp & one){
+            result *= value;
+        }
+        exp >>= one;
+        value *= value;
+    }
+
+    return result;
+}
+
+template <typename Z_e, typename Z_m>
+integer pow(integer base, Z_e exponent, const Z_m modulus){
+    static_assert(std::is_integral <Z_e>::value &&
+                  std::is_integral <Z_m>::value
+                  , "Exponent type should be integral");
+    // check modulus first
+    if (!modulus){
+        throw std::domain_error("Error: modulus by 0");
+    }
+
+    if (exponent < 0){
+        return 0;
+    }
+
+    const Z_e one = 1;
+    integer exp = exponent;
+    const integer mod = modulus;
+
+    integer result = one;
+    while (exp){
+        if (exp & one){
+            result = (result * base) % mod;
+        }
+        exp >>= one;
+        base = (base * base) % mod;
+    }
+
+    return result;
+}
+
+#endif // INTEGER_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,8 +28,6 @@ add_library(src ${src})
 target_link_libraries(src PUBLIC utils)
 target_link_libraries(src PUBLIC external)
 target_link_libraries(src LINK_PUBLIC ${LIBSODIUM_LIBRARY})
-target_link_libraries(src LINK_PUBLIC ${GMP_LIBRARY})
-target_link_libraries(src LINK_PUBLIC ${GMPXX_LIBRARY})
 
 target_link_libraries(src PUBLIC
         $<$<BOOL:${HTTPLIB_IS_USING_OPENSSL}>:OpenSSL::SSL>

--- a/src/internal/biguint.cpp
+++ b/src/internal/biguint.cpp
@@ -1,10 +1,11 @@
 #include <utility>
-#include <gmpxx.h>
 
+#include "bigint/integer.h"
 #include "internal/biguint.h"
 #include "errors.h"
 
-BigUInt::BigUInt(std::string value) : m_value(std::move(value)){}
+BigUInt::BigUInt(std::string value) : m_value(std::move(value))
+{}
 
 std::string BigUInt::getHexValue() const
 {
@@ -12,9 +13,9 @@ std::string BigUInt::getHexValue() const
 
     try
     {
-        mpz_class number(m_value);
+        integer number(m_value, 10);
         number = abs(number);
-        ret = number.get_str(16);
+        ret = number.str(16);
     }
     catch (...)
     {
@@ -29,7 +30,7 @@ std::string BigUInt::getHexValue() const
     return ret;
 }
 
-const std::string& BigUInt::getValue() const
+const std::string &BigUInt::getValue() const
 {
     return m_value;
 }


### PR DESCRIPTION
- **DO NOT** review `integer.h` and `integer.cpp` -> these is the new library used instead of gnu gmp
 Removed `GNU GMP` library, which was only used for big int numbers.
- Replaced `GNU GMP` with `integer library` from [this repo](https://github.com/calccrypto/integer), which has MIT license
- Ran all existing tests successfully :heavy_check_mark:  