### PR TITLE
Github action: build + run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: [ development, main, feat/* ]
+  pull_request:
+    branches: [ development, main, feat/* ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install crypto library libsodium
+        run: sudo apt install libsodium-dev
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Cmake
+        run: cmake .
+
+      - name: Build
+        run: cmake --build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ development, main, feat/* ]
   pull_request:
     branches: [ development, main, feat/* ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,6 +28,7 @@ jobs:
 
   test:
     name: Unit Tests
+    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Build + Unit tests
+name: Unit tests
 
 on:
   push:
@@ -7,32 +7,11 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install crypto library libsodium
-        run: sudo apt install libsodium-dev
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Update submodules
-        run: git submodule update --init --recursive
-
-      - name: Cmake
-        run: cmake .
-
-      - name: Build
-        run: cmake --build .
-
+  call-build:
+    uses: ./github/workflows/build.yml
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: Build
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,7 +14,9 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - uses: ./.github/workflows/build.yml
 
       - name: Unit Tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,5 +20,11 @@ jobs:
       - name: Update submodules
         run: git submodule update --init --recursive
 
+      - name: Cmake
+        run: cmake .
+
+      - name: Build
+        run: cmake --build .
+
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Build + Unit tests
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  test:
-    name: Unit Tests
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Install crypto library libsodium
@@ -26,5 +26,10 @@ jobs:
       - name: Build
         run: cmake --build .
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
       - name: Unit tests
+        uses: Build
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,11 +20,5 @@ jobs:
       - name: Update submodules
         run: git submodule update --init --recursive
 
-      - name: Cmake
-        run: cmake .
-
-      - name: Build
-        run: cmake --build .
-
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,12 +7,13 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  call-build:
-    uses: ./.github/workflows/build.yml
+  #call-build:
+  #  uses: ./.github/workflows/build.yml
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: call-build
     steps:
+      - uses: ./.github/workflows/build.yml
+
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Update submodules
+        run: git submodule update --init --recursive
 
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build
-        uses: ./.github/workflows/build.yml
-
       - name: Unit Tests
+        uses: ./.github/workflows/build.yml
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -28,7 +28,6 @@ jobs:
 
   test:
     name: Unit Tests
-    needs: Build
     runs-on: ubuntu-latest
     steps:
       - name: Unit tests

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - uses: ./.github/workflows/build.yml
+      - uses: .github/workflows/build.yml
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,10 +20,11 @@ jobs:
       - name: Update submodules
         run: git submodule update --init --recursive
 
+      - name: Cmake
+        run: cmake .
+
       - name: Build
-        run:
-          cmake .
-          cmake --build .
+        run: cmake --build .
 
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,8 +29,7 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: Build
     steps:
-      - name: Build
-        uses: Build
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - uses: ./.github/workflows/build.yml
+      - name: Build
+        uses: ./.github/workflows/build.yml
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,8 +7,8 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  call-build:
-    uses: ./.github/workflows/build.yml
+  #call-build:
+  #  uses: ./.github/workflows/build.yml
   test:
     #needs: call-build
     name: Unit Tests
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Call build
-        uses: call-build
+        uses: ./.github/workflows/build.yml
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,8 +7,8 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  test:
-    name: Unit
+  build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Install crypto library libsodium
@@ -26,5 +26,9 @@ jobs:
       - name: Build
         run: cmake --build .
 
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Unit Tests
-        run: scripts.sh
+        run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-build:
-    uses: ./github/workflows/build.yml
+    uses: ./.github/workflows/build.yml
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: [ development, main, feat/* ]
+  pull_request:
+    branches: [ development, main, feat/* ]
+
+jobs:
+  test:
+    name: Unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install crypto library libsodium
+        run: sudo apt install libsodium-dev
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+
+      - name: Unit tests
+        run: script.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,8 +7,8 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  #$call-build:
-  #$  uses: ./.github/workflows/build.yml
+  call-build:
+    uses: ./.github/workflows/build.yml
   test:
     #needs: call-build
     name: Unit Tests
@@ -17,7 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - uses: .github/workflows/build.yml
+      - uses: call-build
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    name: Unit
+    name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - name: Install crypto library libsodium

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - uses: ./.github/workflows/build.yml
+
       - name: Unit Tests
-        uses: ./.github/workflows/build.yml
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,4 +19,4 @@ jobs:
 
 
       - name: Unit tests
-        run: script.sh
+        run: ./script.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -22,7 +22,6 @@ jobs:
 
       - name: Build
         run:
-          -|
           cmake .
           cmake --build .
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,5 +20,11 @@ jobs:
       - name: Update submodules
         run: git submodule update --init --recursive
 
+      - name: Build
+        run:
+          -|
+          cmake .
+          cmake --build .
+
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - uses: call-build
+      - name: Call build
+        uses: call-build
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -30,6 +30,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Unit tests
+      - name: Build
         uses: Build
+      - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,18 +7,24 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  #call-build:
-  #  uses: ./.github/workflows/build.yml
   test:
-    #needs: call-build
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - name: Install crypto library libsodium
+        run: sudo apt install libsodium-dev
+
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Call build
-        uses: ./.github/workflows/build.yml
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Cmake
+        run: cmake .
+
+      - name: Build
+        run: cmake --build .
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,13 +7,12 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  #call-build:
-  #  uses: ./.github/workflows/build.yml
+  call-build:
+    uses: ./.github/workflows/build.yml
   test:
+    needs: call-build
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: ./.github/workflows/build.yml
-
       - name: Unit Tests
-        run: ./scripts.sh
+        run: scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,8 +7,8 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  build:
-    name: Build
+  test:
+    name: Unit
     runs-on: ubuntu-latest
     steps:
       - name: Install crypto library libsodium
@@ -26,9 +26,5 @@ jobs:
       - name: Build
         run: cmake --build .
 
-  test:
-    name: Unit Tests
-    runs-on: ubuntu-latest
-    steps:
       - name: Unit tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -7,14 +7,15 @@ on:
     branches: [ development, main, feat/* ]
 
 jobs:
-  call-build:
-    uses: ./.github/workflows/build.yml
+  #$call-build:
+  #$  uses: ./.github/workflows/build.yml
   test:
-    needs: call-build
+    #needs: call-build
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/workflows/build.yml
 
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: call-build
     steps:
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -19,4 +19,4 @@ jobs:
 
 
       - name: Unit tests
-        run: ./script.sh
+        run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -14,5 +14,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
       - name: Unit Tests
         run: ./scripts.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,5 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: Build
     steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
       - name: Unit Tests
         run: ./scripts.sh

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,3 +1,4 @@
+cmake .
 cmake --build .
 
 function runTests(){

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,3 +1,6 @@
+cmake .
+cmake --build .
+
 function runTests(){
   cd "$1" || exit 1
 

--- a/scripts.sh
+++ b/scripts.sh
@@ -16,3 +16,4 @@ function runTests(){
 cd tests || exit 1
 runTests test_cli
 runTests test_src
+

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,6 +1,3 @@
-cmake .
-cmake --build .
-
 function runTests(){
   cd "$1" || exit 1
 

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,18 +1,18 @@
-cmake .
-cmake --build .
-
 function runTests(){
-  cd "$1" || exit
+  cd "$1" || exit 1
 
   for file in */* ; do
       if [[ "$file" == *"test_"* ]] && [[ -x "$file" ]] && [[ "$file" != *"CMake"* ]]; then
         ./"$file"
+        if [[ $? -ne 0 ]]; then
+          exit 4
+        fi
       fi
   done
 
   cd ..
 }
 
-cd tests || exit
+cd tests || exit 1
 runTests test_cli
 runTests test_src

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,12 +1,9 @@
 cmake --build .
 
-cd tests || exit
-
 function runTests(){
   cd "$1" || exit
 
   for file in */* ; do
-      #echo "$d"
       if [[ "$file" == *"test_"* ]] && [[ -x "$file" ]] && [[ "$file" != *"CMake"* ]]; then
         ./"$file"
       fi
@@ -15,5 +12,6 @@ function runTests(){
   cd ..
 }
 
+cd tests || exit
 runTests test_cli
 runTests test_src

--- a/scripts.sh
+++ b/scripts.sh
@@ -16,4 +16,3 @@ function runTests(){
 cd tests || exit 1
 runTests test_cli
 runTests test_src
-

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,0 +1,22 @@
+cmake --build .
+
+cd tests
+cd test_src
+
+#./test_apiresponse
+#find -type f -executable -exec file -i '{}' \; | grep 'x-executable; charset=binary'
+
+
+tst='test_'
+cmake='CMake'
+for d in */* ; do
+    #echo "$d"
+    if [[ "$d" == *"$tst"* ]]; then
+      if [[ -x "$d" ]]; then
+        if [[ "$d" != *"$cmake"* ]]; then
+          echo "found $d"
+          ./$d
+          fi
+      fi
+    fi
+done

--- a/scripts.sh
+++ b/scripts.sh
@@ -1,22 +1,19 @@
 cmake --build .
 
-cd tests
-cd test_src
+cd tests || exit
 
-#./test_apiresponse
-#find -type f -executable -exec file -i '{}' \; | grep 'x-executable; charset=binary'
+function runTests(){
+  cd "$1" || exit
 
-
-tst='test_'
-cmake='CMake'
-for d in */* ; do
-    #echo "$d"
-    if [[ "$d" == *"$tst"* ]]; then
-      if [[ -x "$d" ]]; then
-        if [[ "$d" != *"$cmake"* ]]; then
-          echo "found $d"
-          ./$d
-          fi
+  for file in */* ; do
+      #echo "$d"
+      if [[ "$file" == *"test_"* ]] && [[ -x "$file" ]] && [[ "$file" != *"CMake"* ]]; then
+        ./"$file"
       fi
-    fi
-done
+  done
+
+  cd ..
+}
+
+runTests test_cli
+runTests test_src

--- a/tests/test_cli/test_inputhandler/CMakeLists.txt
+++ b/tests/test_cli/test_inputhandler/CMakeLists.txt
@@ -1,11 +1,13 @@
 include_directories(${PROJECT_SOURCE_DIR}/cli)
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/tests/test_common)
 
 add_executable(test_inputhandler
 		${PROJECT_SOURCE_DIR}/cli/cli_handler.cpp
 		${PROJECT_SOURCE_DIR}/cli/cli_utility.cpp
 		${PROJECT_SOURCE_DIR}/cli/secretkeyprovider.cpp
 		${PROJECT_SOURCE_DIR}/cli/config/cliconfig.cpp
+		${PROJECT_SOURCE_DIR}/tests/test_common/test_common.h
 		test_inputhandler.cpp)
 
 target_link_libraries(test_inputhandler PUBLIC gtest_main)

--- a/tests/test_cli/test_inputhandler/test_inputhandler.cpp
+++ b/tests/test_cli/test_inputhandler/test_inputhandler.cpp
@@ -37,7 +37,7 @@ TEST(ArgHandler, parse_noArgument_expectInvalid)
 
     EXPECT_EQ(res.requestType, ih::invalid);
     EXPECT_TRUE(res.result.arguments().empty());
-    EXPECT_TRUE(res.help.empty());
+    EXPECT_FALSE(res.help.empty());
 }
 
 TEST(ArgHandler, parse_randomArgs_expectInvalid)

--- a/tests/test_cli/test_inputhandler/test_inputhandler.cpp
+++ b/tests/test_cli/test_inputhandler/test_inputhandler.cpp
@@ -1,10 +1,10 @@
-#include <filehandler/pemreader.h>
 #include <fstream>
 
 #include "gtest/gtest.h"
 #include "inputhandler/ext.h"
 #include "cli_handler.h"
 #include "utils/ext.h"
+#include "test_common.h"
 
 template <typename T>
 void EXPECT_PARSE_ERROR_MISSING_ARG(int const &argc, char *const argv[], errorMessage const &errMsg, std::string const &arg)
@@ -335,6 +335,9 @@ TEST(HandleCreateSignedTransaction, withPemFile_expectCorrectWrittenTx)
     int const argc = 11;
     char *argv[argc];
 
+    std::string keyFile = "--key=" + getCanonicPath("testData/keysValid1.pem");
+    std::string outFile = "--outfile=" + getCanonicPath("testData/outputJson.json");
+
     argv[0] = (char *) "erdcpp";
     argv[1] = (char *) "transaction";
     argv[2] = (char *) "new";
@@ -344,8 +347,8 @@ TEST(HandleCreateSignedTransaction, withPemFile_expectCorrectWrittenTx)
     argv[6] = (char *) "--gas-price=1000000000";
     argv[7] = (char *) "--gas-limit=50000";
     argv[8] = (char *) "--data=test";
-    argv[9] = (char *) "--key=..//..//testData//keysValid1.pem";
-    argv[10] = (char *) "--outfile=..//..//testData//outputJson.json";
+    argv[9] = (char *) keyFile.data();
+    argv[10] = (char *) outFile.data();
 
     ih::ArgHandler argHandler;
     auto const res = argHandler.parse(argc, argv).result;

--- a/tests/test_cli/test_inputhandler/test_inputhandler.cpp
+++ b/tests/test_cli/test_inputhandler/test_inputhandler.cpp
@@ -37,7 +37,7 @@ TEST(ArgHandler, parse_noArgument_expectInvalid)
 
     EXPECT_EQ(res.requestType, ih::invalid);
     EXPECT_TRUE(res.result.arguments().empty());
-    EXPECT_FALSE(res.help.empty());
+    EXPECT_TRUE(res.help.empty());
 }
 
 TEST(ArgHandler, parse_randomArgs_expectInvalid)

--- a/tests/test_common/test_common.h
+++ b/tests/test_common/test_common.h
@@ -1,0 +1,16 @@
+#ifndef ERDCPP_TEST_COMMON_H
+#define ERDCPP_TEST_COMMON_H
+
+#include "string"
+
+std::string getCanonicPath(std::string const &path)
+{
+    // Get absolute path to executable
+    std::string canonicPath = std::string(canonicalize_file_name("/proc/self/exe"));
+
+    // Remove everything in path until tests directory and concatenate it with test file data path
+    canonicPath = canonicPath.substr(0, canonicPath.find("tests"));
+    return canonicPath + "tests/" + path;
+}
+
+#endif //ERDCPP_TEST_COMMON_H

--- a/tests/test_src/test_filehandler/CMakeLists.txt
+++ b/tests/test_src/test_filehandler/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_SOURCE_DIR}/tests/test_common)
 
-add_executable(test_filehandler test_filehandler.cpp)
+add_executable(test_filehandler
+        ${PROJECT_SOURCE_DIR}/tests/test_common/test_common.h
+        test_filehandler.cpp)
 
 target_link_libraries(test_filehandler PUBLIC gtest_main)
 target_link_libraries(test_filehandler PUBLIC src)

--- a/tests/test_src/test_filehandler/test_filehandler.cpp
+++ b/tests/test_src/test_filehandler/test_filehandler.cpp
@@ -67,17 +67,17 @@ INSTANTIATE_TEST_SUITE_P(
         ValidPemFiles,
         PemFileReaderParametrized,
         ::testing::Values
-        (pemData {getCanonicPath("testData/keysValid2.pem"),                                               // File path
-                  "413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9",        // Seed
-                  "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1",    // Public key
-                  "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"}, // Bech32 address
+        (pemData {getCanonicPath("testData/keysValid2.pem"),                          // File path
+                  "413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9", // Seed
+                  "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1", // Public key
+                  "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"},  // Bech32 address
 
-         pemData {getCanonicPath("testData/keysValid3.pem"),                                   // File path
+         pemData {getCanonicPath("testData/keysValid3.pem"),                            // File path
                   "b8ca6f8203fb4b545a8e83c5384da033c415db155b53fb5b8eba7ff5a039d639",   // Seed
                   "8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8",   // Public key
                   "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"},    // Bech32 address
 
-         pemData {getCanonicPath("testData/keysValid4.pem"),                                   // File path
+         pemData {getCanonicPath("testData/keysValid4.pem"),                            // File path
                   "e253a571ca153dc2aee845819f74bcc9773b0586edead15a94cb7235a5027436",   // Seed
                   "b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba",   // Public key
                   "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"}));  // Bech32 address

--- a/tests/test_src/test_filehandler/test_filehandler.cpp
+++ b/tests/test_src/test_filehandler/test_filehandler.cpp
@@ -5,6 +5,15 @@
 #include "filehandler/pemreader.h"
 #include "filehandler/keyfilereader.h"
 
+std::string getCanonicPath(std::string const& path) {
+    // Get absolute path to executable
+    std::string canonicPath = std::string (canonicalize_file_name("/proc/self/exe"));
+
+    // Remove everything in path after test_src and concatenate it with test file data path
+    canonicPath = canonicPath.substr(0, canonicPath.find("test_src"));
+    return canonicPath += path;
+}
+
 class PemFileReaderConstructorFixture : public ::testing::Test
 {
 public:
@@ -29,27 +38,27 @@ public:
 
 TEST_F(PemFileReaderConstructorFixture, validFile)
 {
-    EXPECT_NO_THROW(PemFileReader pemHandler("..//..//testData//keysValid1.pem"));
+    EXPECT_NO_THROW(PemFileReader pemHandler(getCanonicPath("testData/keysValid1.pem")));
 }
 
 TEST_F(PemFileReaderConstructorFixture, invalidFile_notEnoughBytes)
 {
-    expectException<std::length_error>("..//..//testData//keysNotEnoughBytes.pem",ERROR_MSG_KEY_BYTES_SIZE);
+    expectException<std::length_error>(getCanonicPath("testData/keysNotEnoughBytes.pem"),ERROR_MSG_KEY_BYTES_SIZE);
 }
 
 TEST_F(PemFileReaderConstructorFixture, invalidFile_invalidFileExtension)
 {
-    expectException<std::invalid_argument>("..//..//testData//keysInvalidExtension.pme",ERROR_MSG_FILE_EXTENSION_INVALID);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keysInvalidExtension.pme"),ERROR_MSG_FILE_EXTENSION_INVALID);
 }
 
 TEST_F(PemFileReaderConstructorFixture, invalidFile_emptyFile)
 {
-    expectException<std::invalid_argument>("..//..//testData//keysEmptyFile.pem",ERROR_MSG_FILE_EMPTY);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keysEmptyFile.pem"),ERROR_MSG_FILE_EMPTY);
 }
 
 TEST_F(PemFileReaderConstructorFixture, invalidFile_notExisting)
 {
-    expectException<std::invalid_argument>("..//..//testData//thisFileDoesNotExist.pem",ERROR_MSG_FILE_DOES_NOT_EXIST);
+    expectException<std::invalid_argument>(getCanonicPath("testData/thisFileDoesNotExist.pem"),ERROR_MSG_FILE_DOES_NOT_EXIST);
 }
 
 struct pemData
@@ -62,21 +71,21 @@ struct pemData
 
 class PemFileReaderParametrized : public ::testing::TestWithParam<pemData> {};
 
-INSTANTIATE_TEST_CASE_P (
+INSTANTIATE_TEST_SUITE_P(
         ValidPemFiles,
         PemFileReaderParametrized,
         ::testing::Values
-        (pemData {"..//..//testData//keysValid2.pem",                                   // File path
-                  "413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9",   // Seed
-                  "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1",   // Public key
-                  "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"},    // Bech32 address
+        (pemData {getCanonicPath("testData/keysValid2.pem"),                                               // File path
+                  "413f42575f7f26fad3317a778771212fdb80245850981e48b58a4f25e344e8f9",        // Seed
+                  "0139472eff6886771a982f3083da5d421f24c29181e63888228dc81ca60d69e1",    // Public key
+                  "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th"}, // Bech32 address
 
-         pemData {"..//..//testData//keysValid3.pem",                                   // File path
+         pemData {getCanonicPath("testData/keysValid3.pem"),                                   // File path
                   "b8ca6f8203fb4b545a8e83c5384da033c415db155b53fb5b8eba7ff5a039d639",   // Seed
                   "8049d639e5a6980d1cd2392abcce41029cda74a1563523a202f09641cc2618f8",   // Public key
                   "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"},    // Bech32 address
 
-         pemData {"..//..//testData//keysValid4.pem",                                   // File path
+         pemData {getCanonicPath("testData/keysValid4.pem"),                                   // File path
                   "e253a571ca153dc2aee845819f74bcc9773b0586edead15a94cb7235a5027436",   // Seed
                   "b2a11555ce521e4944e09ab17549d85b487dcd26c84b5017a39e31a3670889ba",   // Public key
                   "erd1k2s324ww2g0yj38qn2ch2jwctdy8mnfxep94q9arncc6xecg3xaq6mjse8"}));  // Bech32 address
@@ -120,40 +129,40 @@ public:
 
 TEST_F(KeyFileReaderConstructorFixture, invalidMac)
 {
-    expectException<std::runtime_error>("..//..//testData//keyFileInvalidMac.json", "", ERROR_MSG_MAC);
+    expectException<std::runtime_error>(getCanonicPath("testData/keyFileInvalidMac.json"), "", ERROR_MSG_MAC);
 }
 
 TEST_F(KeyFileReaderConstructorFixture, invalidVersion)
 {
-    expectException<std::invalid_argument>("..//..//testData//keyFileInvalidVersion.json", "", ERROR_MSG_KEY_FILE_VERSION);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keyFileInvalidVersion.json"), "", ERROR_MSG_KEY_FILE_VERSION);
 }
 
 TEST_F(KeyFileReaderConstructorFixture, invalidCipher)
 {
-    expectException<std::invalid_argument>("..//..//testData//keyFileInvalidCipher.json", "", ERROR_MSG_KEY_FILE_CIPHER);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keyFileInvalidCipher.json"), "", ERROR_MSG_KEY_FILE_CIPHER);
 }
 
 TEST_F(KeyFileReaderConstructorFixture, invalidKdf)
 {
-    expectException<std::invalid_argument>("..//..//testData//keyFileInvalidKdf.json", "", ERROR_MSG_KEY_FILE_DERIVATION_FUNCTION);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keyFileInvalidKdf.json"), "", ERROR_MSG_KEY_FILE_DERIVATION_FUNCTION);
 }
 
 TEST_F(KeyFileReaderConstructorFixture, invalidContent)
 {
-    expectException<std::invalid_argument>("..//..//testData//keyFileInvalidContent.json", "", ERROR_MSG_KEY_FILE);
+    expectException<std::invalid_argument>(getCanonicPath("testData/keyFileInvalidContent.json"), "", ERROR_MSG_KEY_FILE);
 }
 
 // These tests are adapted from :
 // https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/main/src/testutils/wallets.ts
 TEST(KeyFileReader, getAddress_getSeed_differentFiles)
 {
-    KeyFileReader aliceKeyFile("..//..//testData//aliceKeyFile.json", "password");
-    KeyFileReader bobKeyFile("..//..//testData//bobKeyFile.json", "password");
-    KeyFileReader carolKeyFile("..//..//testData//carolKeyFile.json", "password");
+    KeyFileReader aliceKeyFile(getCanonicPath("testData/aliceKeyFile.json"), "password");
+    KeyFileReader bobKeyFile(getCanonicPath("testData/bobKeyFile.json"), "password");
+    KeyFileReader carolKeyFile(getCanonicPath("testData/carolKeyFile.json"), "password");
 
-    PemFileReader alicePem("..//..//testData//alicePem.pem");
-    PemFileReader bobPem("..//..//testData//bobPem.pem");
-    PemFileReader carolPem("..//..//testData//carolPem.pem");
+    PemFileReader alicePem(getCanonicPath("testData/alicePem.pem"));
+    PemFileReader bobPem(getCanonicPath("testData/bobPem.pem"));
+    PemFileReader carolPem(getCanonicPath("testData/carolPem.pem"));
 
     EXPECT_EQ(aliceKeyFile.getAddress().getBech32Address(), "erd1qyu5wthldzr8wx5c9ucg8kjagg0jfs53s8nr3zpz3hypefsdd8ssycr6th");
     EXPECT_EQ(bobKeyFile.getAddress().getBech32Address(), "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx");

--- a/tests/test_src/test_filehandler/test_filehandler.cpp
+++ b/tests/test_src/test_filehandler/test_filehandler.cpp
@@ -1,18 +1,10 @@
 #include "gtest/gtest.h"
 
 #include "utils/hex.h"
+#include "test_common.h"
 #include "utils/errors.h"
 #include "filehandler/pemreader.h"
 #include "filehandler/keyfilereader.h"
-
-std::string getCanonicPath(std::string const& path) {
-    // Get absolute path to executable
-    std::string canonicPath = std::string (canonicalize_file_name("/proc/self/exe"));
-
-    // Remove everything in path after test_src and concatenate it with test file data path
-    canonicPath = canonicPath.substr(0, canonicPath.find("test_src"));
-    return canonicPath += path;
-}
 
 class PemFileReaderConstructorFixture : public ::testing::Test
 {


### PR DESCRIPTION
- Added `github/workflows` ymls for build + test. Unfortunately, could not reuse build yml in test yml
- Added `scripts.sh` which will try to run all tests in `test_cli` && `test_src`. It does si by iterating in all directories/subdirectories and tries to find all test executables.
- Added `test_common.h`, which contains `getCanonicPath` to get the canonical path of a file. This way, we would not use relative path to the executable, which can be called withing another executable, making the first relative path wrong. This is necessary so that no matter where the test is executed, the path is valid