### PR TITLE
ESDTNFTTransfer payload builder

### DIFF
--- a/include/internal/biguint.h
+++ b/include/internal/biguint.h
@@ -6,6 +6,8 @@
 class BigUInt
 {
 public:
+    explicit BigUInt(uint64_t value);
+
     explicit BigUInt(std::string value);
 
     BigUInt operator*(BigUInt const &rhs);

--- a/include/transaction/esdt.h
+++ b/include/transaction/esdt.h
@@ -4,6 +4,8 @@
 #include "transaction.h"
 #include "scarguments.h"
 
+#define ESDT_NFT_TRANSFER_PREFIX std::string("ESDTNFTTransfer")
+
 #define ESDT_TRANSFER_PREFIX std::string("ESDTTransfer")
 #define ESDT_TRANSFER_GAS_LIMIT_NO_FUNCTION 500000
 #define ESDT_TRANSFER_NO_FUNCTION std::string()

--- a/include/transaction/payload_builder.h
+++ b/include/transaction/payload_builder.h
@@ -3,6 +3,7 @@
 
 // This file is an adaptation from https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/main/src/tokenTransferBuilders.ts
 
+#include "account/address.h"
 #include "transaction/token_payment.h"
 
 class ESDTTransferPayloadBuilder
@@ -12,10 +13,26 @@ public:
 
     ESDTTransferPayloadBuilder &setPayment(TokenPayment payment);
 
-    std::string build( ) const;
+    std::string build() const;
 
 private:
     TokenPayment m_payment;
+};
+
+class ESDTNFTTransferPayloadBuilder
+{
+public:
+    explicit ESDTNFTTransferPayloadBuilder();
+
+    ESDTNFTTransferPayloadBuilder &setPayment(TokenPayment payment);
+
+    ESDTNFTTransferPayloadBuilder &setDestination(Address const &address);
+
+    std::string build() const;
+
+private:
+    TokenPayment m_payment;
+    std::string m_destination;
 };
 
 #endif //ERD_PAYLOAD_BUILDER_H

--- a/include/transaction/token_payment.h
+++ b/include/transaction/token_payment.h
@@ -11,6 +11,8 @@ public:
 
     static TokenPayment fungibleFromBigUInt(std::string tokenIdentifier, BigUInt value, uint32_t numDecimals = 0);
 
+    static TokenPayment semiFungible(std::string tokenIdentifier, uint64_t nonce, BigUInt quantity);
+
     static TokenPayment nonFungible(std::string tokenIdentifier, uint64_t nonce);
 
     static TokenPayment metaESDTFromAmount(std::string tokenIdentifier, uint64_t nonce, std::string amount, uint32_t numDecimals);

--- a/src/internal/biguint.cpp
+++ b/src/internal/biguint.cpp
@@ -7,6 +7,12 @@
 #define BASE_10 10
 #define BASE_16 16
 
+BigUInt::BigUInt(uint64_t value)
+{
+    std::string valueStr = std::to_string(value);
+    m_value = std::move(valueStr);
+}
+
 BigUInt::BigUInt(std::string value)
 {
     try
@@ -75,3 +81,4 @@ std::pair<BigUInt, BigUInt> BigUInt::divmod(const BigUInt &rhs) const
 
     return {retV1, retV2};
 }
+

--- a/src/internal/biguint.cpp
+++ b/src/internal/biguint.cpp
@@ -81,4 +81,3 @@ std::pair<BigUInt, BigUInt> BigUInt::divmod(const BigUInt &rhs) const
 
     return {retV1, retV2};
 }
-

--- a/src/transaction/payload_builder.cpp
+++ b/src/transaction/payload_builder.cpp
@@ -20,3 +20,30 @@ std::string ESDTTransferPayloadBuilder::build() const
 
     return ESDT_TRANSFER_PREFIX + args.asOnData();
 }
+
+ESDTNFTTransferPayloadBuilder::ESDTNFTTransferPayloadBuilder() :
+        m_payment(TokenPayment::fungibleFromAmount("", "0", 0))
+{}
+
+ESDTNFTTransferPayloadBuilder &ESDTNFTTransferPayloadBuilder::setPayment(TokenPayment payment)
+{
+    m_payment = std::move(payment);
+    return *this;
+}
+
+ESDTNFTTransferPayloadBuilder &ESDTNFTTransferPayloadBuilder::setDestination(Address const &address)
+{
+    m_destination = address.getBech32Address();
+    return *this;
+}
+
+std::string ESDTNFTTransferPayloadBuilder::build() const
+{
+    SCArguments args;
+    args.add(m_payment.tokenIdentifier());
+    args.add(BigUInt(m_payment.nonce()));
+    args.add(m_payment.value());
+    args.add(Address(m_destination));
+
+    return ESDT_NFT_TRANSFER_PREFIX + args.asOnData();
+}

--- a/src/transaction/token_payment.cpp
+++ b/src/transaction/token_payment.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <utility>
 
 #include "errors.h"
 #include "transaction/token_payment.h"
@@ -113,6 +114,11 @@ TokenPayment TokenPayment::fungibleFromBigUInt(std::string tokenIdentifier, BigU
 TokenPayment TokenPayment::nonFungible(std::string tokenIdentifier, uint64_t nonce)
 {
     return {std::move(tokenIdentifier), nonce, BigUInt("1"), 0};
+}
+
+TokenPayment TokenPayment::semiFungible(std::string tokenIdentifier, uint64_t nonce, BigUInt quantity)
+{
+    return {std::move(tokenIdentifier), nonce, std::move(quantity), 0};
 }
 
 TokenPayment TokenPayment::metaESDTFromAmount(std::string tokenIdentifier, uint64_t nonce, std::string amount, uint32_t numDecimals)

--- a/tests/test_src/test_transaction/test_payload_builder.cpp
+++ b/tests/test_src/test_transaction/test_payload_builder.cpp
@@ -12,3 +12,15 @@ TEST(ESDTTransferPayloadBuilder, build)
     payload = ESDTTransferPayloadBuilder().setPayment(payment).build();
     EXPECT_EQ(payload, "ESDTTransfer@524944452d376431386539@589624641c2ba8e046");
 }
+
+TEST(ESDTNFTTransferPayloadBuilder, build)
+{
+    TokenPayment payment = TokenPayment::semiFungible("SEMI-9efd0f", 1, BigUInt(5));
+
+    std::string payload = ESDTNFTTransferPayloadBuilder()
+            .setPayment(payment)
+            .setDestination(Address("erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7"))
+            .build();
+
+    EXPECT_EQ(payload, "ESDTNFTTransfer@53454d492d396566643066@01@05@5e60b9ff2385ea27ba0c3da4689779a8f7364acee1db0ee7bee59ac660a28974");
+}

--- a/tests/test_src/test_transaction/test_payload_builder.cpp
+++ b/tests/test_src/test_transaction/test_payload_builder.cpp
@@ -15,12 +15,24 @@ TEST(ESDTTransferPayloadBuilder, build)
 
 TEST(ESDTNFTTransferPayloadBuilder, build)
 {
-    TokenPayment payment = TokenPayment::semiFungible("SEMI-9efd0f", 1, BigUInt(5));
-
+    TokenPayment sft = TokenPayment::semiFungible("SEMI-9efd0f", 1, BigUInt(5));
     std::string payload = ESDTNFTTransferPayloadBuilder()
-            .setPayment(payment)
+            .setPayment(sft)
             .setDestination(Address("erd1testnlersh4z0wsv8kjx39me4rmnvjkwu8dsaea7ukdvvc9z396qykv7z7"))
             .build();
-
     EXPECT_EQ(payload, "ESDTNFTTransfer@53454d492d396566643066@01@05@5e60b9ff2385ea27ba0c3da4689779a8f7364acee1db0ee7bee59ac660a28974");
+
+    TokenPayment nft = TokenPayment::nonFungible("OGS-3f1408", 2111);
+    payload = ESDTNFTTransferPayloadBuilder()
+            .setPayment(nft)
+            .setDestination(Address("erd1q637cys8k0squ5xun22kwycqp63wa9edxuk779tjwazsvmyqcr2sgpkmx5"))
+            .build();
+    EXPECT_EQ(payload, "ESDTNFTTransfer@4f47532d336631343038@083f@01@06a3ec1207b3e00e50dc9a956713000ea2ee972d372def15727745066c80c0d5");
+
+    TokenPayment metaESDT = TokenPayment::metaESDTFromAmount("LKMEX-aab910", 3983756, "54268.574065528382947328", 18);
+    payload = ESDTNFTTransferPayloadBuilder()
+            .setPayment(metaESDT)
+            .setDestination(Address("erd1qqqqqqqqqqqqqpgqt7tyyswqvplpcqnhwe20xqrj7q7ap27d2jps7zczse"))
+            .build();
+    EXPECT_EQ(payload, "ESDTNFTTransfer@4c4b4d45582d616162393130@3cc98c@0b7de7c1695eab800000@000000000000000005005f964241c0607e1c02777654f30072f03dd0abcd5483");
 }


### PR DESCRIPTION
- Added support for `ESDTNFTTransfer` payload builder, which works with sfts, nfts and metaESDTs. Please be aware that `setDestinations` saves bech32 address instead of `Address` object **on purpose**.
- Added `BigUInt` constructor from `uint64` value
- Added `TokenPayment` constructor from `semiFungile`