### PR TITLE
Replace string with BigUInt

### DIFF
--- a/cli/cli_handler.cpp
+++ b/cli/cli_handler.cpp
@@ -83,7 +83,7 @@ void handleIssueESDT(cxxopts::ParseResult const &result)
             esdtProperties
     )->buildSigned(keyFile->getSeed());
 
-    auto const txHash = proxy.send(tx).hash;
+    auto const txHash = proxy.send(tx);
     std::cerr << "Transaction hash: " << txHash << "\n";
 }
 
@@ -123,7 +123,7 @@ void handleTransferESDT(cxxopts::ParseResult const &result)
     tx.m_gasLimit = GasEstimator(cfg).forESDTTransfer(tx.m_data->size());
     utility::signTransaction(tx, keyFile);
 
-    auto const txHash = proxy.send(tx).hash;
+    auto const txHash = proxy.send(tx);
     std::cerr << "Transaction hash: " << txHash << "\n";
 }
 

--- a/cli/inputhandler/wrappers/transaction_input_wrapper.cpp
+++ b/cli/inputhandler/wrappers/transaction_input_wrapper.cpp
@@ -6,7 +6,7 @@
 namespace internal
 {
 template<class T>
-inline std::shared_ptr<T> getUserInputIfExists(cxxopts::ParseResult const & userInputs,
+inline std::shared_ptr<T> getUserInputIfExists(cxxopts::ParseResult const &userInputs,
                                                std::string const &arg)
 {
     if (userInputs.count(arg))
@@ -18,7 +18,7 @@ inline std::shared_ptr<T> getUserInputIfExists(cxxopts::ParseResult const & user
 }
 
 template<>
-inline std::shared_ptr<bytes> getUserInputIfExists(cxxopts::ParseResult const & userInputs,
+inline std::shared_ptr<bytes> getUserInputIfExists(cxxopts::ParseResult const &userInputs,
                                                    std::string const &arg)
 {
     if (userInputs.count(arg))
@@ -30,7 +30,7 @@ inline std::shared_ptr<bytes> getUserInputIfExists(cxxopts::ParseResult const & 
     else return nullptr;
 }
 
-template <typename T>
+template<typename T>
 inline T getUserInputOrDefault(cxxopts::ParseResult const &userInputs, std::string const &value, T const &defaultValue)
 {
     return (userInputs.count(value) != 0) ?
@@ -43,23 +43,24 @@ namespace ih
 namespace wrapper
 {
 
-TransactionInputWrapper::TransactionInputWrapper(cxxopts::ParseResult const  &inputData) : IWrapper(inputData) {}
+TransactionInputWrapper::TransactionInputWrapper(cxxopts::ParseResult const &inputData) : IWrapper(inputData)
+{}
 
 uint64_t TransactionInputWrapper::getNonce() const
 {
     return internal::getUserInputOrDefault<uint64_t>(getInputData(), "nonce", DEFAULT_NONCE);
 }
 
-std::string TransactionInputWrapper::getValue() const
+BigUInt TransactionInputWrapper::getValue() const
 {
-    return internal::getUserInputOrDefault<std::string>(getInputData(), "value", DEFAULT_VALUE);
+    return BigUInt(internal::getUserInputOrDefault<std::string>(getInputData(), "value", DEFAULT_VALUE.getValue()));
 }
 
 std::shared_ptr<Address> TransactionInputWrapper::getReceiver() const
 {
     if (getInputData().count("receiver") != 0)
     {
-        std::string const bech32Address= getInputData()["receiver"].as<std::string>();
+        std::string const bech32Address = getInputData()["receiver"].as<std::string>();
         Address const receiver(bech32Address);
         return std::make_shared<Address>(receiver);
     }

--- a/cli/inputhandler/wrappers/transaction_input_wrapper.h
+++ b/cli/inputhandler/wrappers/transaction_input_wrapper.h
@@ -3,6 +3,7 @@
 
 #include "iwrapper.h"
 #include "account/address.h"
+#include "internal/biguint.h"
 
 namespace ih
 {
@@ -15,7 +16,7 @@ public:
 
     uint64_t getNonce() const;
 
-    std::string getValue() const;
+    BigUInt getValue() const;
 
     std::shared_ptr<Address> getReceiver() const;
 

--- a/include/account/account.h
+++ b/include/account/account.h
@@ -2,24 +2,24 @@
 #define ERD_ACCOUNT_H
 
 #include "address.h"
-#include <string>
+#include "internal/biguint.h"
 
 #ifndef DEFAULT_NONCE
     #define DEFAULT_NONCE 0U
 #endif
 
-#define DEFAULT_BALANCE "0"
+#define DEFAULT_BALANCE BigUInt(0)
 
 class Account
 {
 public:
     explicit Account(Address address);
 
-    explicit Account(Address address, std::string balance, uint64_t const &nonce);
+    explicit Account(Address address, BigUInt balance, uint64_t const &nonce);
 
     const Address& getAddress() const;
 
-    const std::string& getBalance() const;
+    const BigUInt& getBalance() const;
 
     const uint64_t& getNonce() const;
 
@@ -27,7 +27,7 @@ public:
 
 private:
     uint64_t m_nonce;
-    std::string m_balance;
+    BigUInt m_balance;
     Address const m_address;
 };
 

--- a/include/internal/biguint.h
+++ b/include/internal/biguint.h
@@ -10,7 +10,9 @@ public:
 
     explicit BigUInt(std::string value);
 
-    BigUInt operator*(BigUInt const &rhs);
+    BigUInt operator*(BigUInt const &rhs) const;
+
+    BigUInt operator/(BigUInt const &rhs) const;
 
     bool operator==(BigUInt const &rhs);
 

--- a/include/provider/data/data_transaction.h
+++ b/include/provider/data/data_transaction.h
@@ -3,12 +3,6 @@
 
 #include <string>
 
-struct TransactionHash
-{
-    // Transaction hash in hex
-    std::string hash;
-};
-
 // Also see ERDJS implementation:
 // https://github.com/ElrondNetwork/elrond-sdk-erdjs/blob/5c10d7d69dbc424464909398d0874684b59cb2c4/src/transaction.ts#L455
 class TransactionStatus

--- a/include/provider/proxyprovider.h
+++ b/include/provider/proxyprovider.h
@@ -19,9 +19,9 @@ public:
 
     TransactionStatus getTransactionStatus(std::string const &txHash);
 
-    std::string getESDTTokenBalance(Address const &address, std::string const &token) const;
+    BigUInt getESDTBalance(Address const &address, std::string const &token) const;
 
-    std::map<std::string, std::string> getAllESDTTokenBalances(Address const &address) const;
+    std::map<std::string, BigUInt> getAllESDTBalances(Address const &address) const;
 
     NetworkConfig getNetworkConfig() const;
 

--- a/include/provider/proxyprovider.h
+++ b/include/provider/proxyprovider.h
@@ -15,7 +15,7 @@ public:
 
     Account getAccount(Address const &address);
 
-    TransactionHash send(Transaction const &transaction);
+    std::string send(Transaction const &transaction);
 
     TransactionStatus getTransactionStatus(std::string const &txHash);
 

--- a/include/transaction/transaction.h
+++ b/include/transaction/transaction.h
@@ -1,6 +1,7 @@
 #ifndef ERD_TRANSACTION_H
 #define ERD_TRANSACTION_H
 
+#include "internal/biguint.h"
 #include "account/address.h"
 #include "transaction/signer.h"
 
@@ -9,7 +10,7 @@
 #include <memory>
 
 #define DEFAULT_NONCE 0U
-#define DEFAULT_VALUE "0"
+#define DEFAULT_VALUE BigUInt(0)
 #define DEFAULT_RECEIVER nullptr
 #define DEFAULT_SENDER nullptr
 #define DEFAULT_RECEIVER_NAME nullptr
@@ -27,7 +28,7 @@ class Transaction
 public:
     explicit Transaction(
             uint64_t const &nonce,
-            std::string value,
+            BigUInt value,
             Address const &receiver,
             Address const &sender,
             std::shared_ptr<bytes> receiverUserName,
@@ -51,7 +52,7 @@ public:
     void deserialize(std::string const& serializedTransaction);
 
     uint64_t m_nonce;
-    std::string m_value;
+    BigUInt m_value;
     std::shared_ptr<bytes> m_receiverUserName;
     std::shared_ptr<bytes> m_senderUserName;
     std::shared_ptr<Address> m_receiver;

--- a/src/account/account.cpp
+++ b/src/account/account.cpp
@@ -8,7 +8,7 @@ Account::Account(Address address) :
         m_nonce(DEFAULT_NONCE)
 {}
 
-Account::Account(Address address, std::string balance, uint64_t const &nonce) :
+Account::Account(Address address, BigUInt balance, uint64_t const &nonce) :
         m_address(std::move(address)),
         m_balance(std::move(balance)),
         m_nonce(nonce)
@@ -19,7 +19,7 @@ const Address& Account::getAddress() const
     return m_address;
 }
 
-const std::string& Account::getBalance() const
+const BigUInt& Account::getBalance() const
 {
     return m_balance;
 }

--- a/src/internal/biguint.cpp
+++ b/src/internal/biguint.cpp
@@ -61,7 +61,7 @@ const std::string &BigUInt::getValue() const
     return m_value;
 }
 
-BigUInt BigUInt::operator*(const BigUInt &rhs)
+BigUInt BigUInt::operator*(const BigUInt &rhs) const
 {
     integer v1(m_value, BASE_10);
     integer v2(rhs.getValue(), BASE_10);
@@ -85,4 +85,9 @@ std::pair<BigUInt, BigUInt> BigUInt::divmod(const BigUInt &rhs) const
     BigUInt retV2 = BigUInt(res.second.str());
 
     return {retV1, retV2};
+}
+
+BigUInt BigUInt::operator/(const BigUInt &rhs) const
+{
+    return this->divmod(rhs).first;
 }

--- a/src/provider/proxyprovider.cpp
+++ b/src/provider/proxyprovider.cpp
@@ -41,7 +41,7 @@ Account ProxyProvider::getAccount(Address const &address)
     std::string const balance = data["account"]["balance"];
     uint64_t const nonce = data["account"]["nonce"];
 
-    return Account(address, balance, nonce);
+    return Account(address, BigUInt(balance), nonce);
 }
 
 std::string ProxyProvider::send(Transaction const &transaction)
@@ -69,7 +69,7 @@ TransactionStatus ProxyProvider::getTransactionStatus(std::string const &txHash)
     return TransactionStatus(txStatus);
 }
 
-std::string ProxyProvider::getESDTTokenBalance(Address const &address, std::string const &token) const
+BigUInt ProxyProvider::getESDTBalance(Address const &address, std::string const &token) const
 {
     wrapper::http::Client client(m_url);
     wrapper::http::Result const result = client.get("/address/" + address.getBech32Address() + "/esdt/" + token);
@@ -81,10 +81,10 @@ std::string ProxyProvider::getESDTTokenBalance(Address const &address, std::stri
 
     std::string balance = data["tokenData"]["balance"];
 
-    return balance;
+    return BigUInt(balance);
 }
 
-std::map<std::string, std::string> ProxyProvider::getAllESDTTokenBalances(Address const &address) const
+std::map<std::string, BigUInt> ProxyProvider::getAllESDTBalances(Address const &address) const
 {
     wrapper::http::Client client(m_url);
     wrapper::http::Result const result = client.get("/address/" + address.getBech32Address() + "/esdt");
@@ -95,7 +95,7 @@ std::map<std::string, std::string> ProxyProvider::getAllESDTTokenBalances(Addres
 
     auto esdts = data["esdts"];
 
-    std::map<std::string, std::string> ret;
+    std::map<std::string, BigUInt> ret;
     std::string esdt;
     std::string balance;
 
@@ -105,7 +105,7 @@ std::map<std::string, std::string> ProxyProvider::getAllESDTTokenBalances(Addres
 
         esdt = it.key();
         balance = it.value()["balance"];
-        ret[esdt] = balance;
+        ret.emplace(esdt, BigUInt(balance));
     }
 
     return ret;

--- a/src/provider/proxyprovider.cpp
+++ b/src/provider/proxyprovider.cpp
@@ -44,7 +44,7 @@ Account ProxyProvider::getAccount(Address const &address)
     return Account(address, balance, nonce);
 }
 
-TransactionHash ProxyProvider::send(Transaction const &transaction)
+std::string ProxyProvider::send(Transaction const &transaction)
 {
     wrapper::http::Client client(m_url);
     wrapper::http::Result const result = client.post("/transaction/send", transaction.serialize(), wrapper::http::applicationJson);
@@ -52,10 +52,7 @@ TransactionHash ProxyProvider::send(Transaction const &transaction)
     auto data = internal::getPayLoad(result);
 
     utility::requireAttribute(data, "txHash");
-
-    std::string const txHash = data["txHash"];
-
-    return TransactionHash{txHash};
+    return data["txHash"];
 }
 
 TransactionStatus ProxyProvider::getTransactionStatus(std::string const &txHash)

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -55,7 +55,7 @@ std::string getSerializedTxMsg(Transaction tx, bool const withSignature)
 
 Transaction::Transaction(
         uint64_t const &nonce,
-        std::string value,
+        BigUInt value,
         Address const &receiver,
         Address const &sender,
         std::shared_ptr<bytes> receiverUserName,
@@ -125,7 +125,7 @@ std::string Transaction::serialize() const
     wrapper::json::OrderedJson json;
 
     json.set(TX_NONCE, m_nonce);
-    json.set(TX_VALUE, m_value);
+    json.set(TX_VALUE, m_value.getValue());
     json.set(TX_RECEIVER, (*m_receiver).getBech32Address());
     json.set(TX_SENDER, (*m_sender).getBech32Address());
     internal::setJsonValueIfNotNull(json, TX_RECEIVER_NAME, m_receiverUserName);
@@ -164,7 +164,7 @@ void Transaction::deserialize(std::string const &serializedTransaction)
     if (!json.contains(TX_VERSION)) throw std::invalid_argument(ERROR_MSG_VERSION);
 
     m_nonce = json.at<uint64_t>(TX_NONCE);
-    m_value = json.at<std::string>(TX_VALUE);
+    m_value = BigUInt(json.at<std::string>(TX_VALUE));
     m_receiver.reset(new Address(json.at<std::string>(TX_RECEIVER)));
     m_sender.reset(new Address(json.at<std::string>(TX_SENDER)));
     m_gasPrice = json.at<uint64_t>(TX_GAS_PRICE);

--- a/src/transaction/transaction_builders.cpp
+++ b/src/transaction/transaction_builders.cpp
@@ -26,7 +26,7 @@ Transaction TransactionEGLDTransferBuilder::build()
 
     return Transaction(
             m_txInput.nonce,
-            m_txInput.value.getValue(),
+            m_txInput.value,
             m_txInput.receiver,
             m_txInput.sender,
             DEFAULT_SENDER_NAME,

--- a/tests/test_src/test_account/test_account.cpp
+++ b/tests/test_src/test_account/test_account.cpp
@@ -68,7 +68,7 @@ INSTANTIATE_TEST_CASE_P (
 
 TEST_P(AddressParametrized, getPublicKey_getBech32Address)
 {
-    addrData const& currParam = GetParam();
+    addrData const &currParam = GetParam();
 
     bytes const pubKey = util::hexToBytes(currParam.publicKey);
     std::string const bech32Address = currParam.bech32Address;
@@ -118,8 +118,8 @@ TEST(Account, constructor_defaultValues)
     Account const account(address);
 
     EXPECT_TRUE (account.getAddress() == address);
-    EXPECT_EQ(account.getBalance(), DEFAULT_BALANCE);
-    EXPECT_EQ(account.getNonce(), DEFAULT_NONCE );
+    EXPECT_EQ(account.getBalance().getValue(), DEFAULT_BALANCE.getValue());
+    EXPECT_EQ(account.getNonce(), DEFAULT_NONCE);
 }
 
 TEST(Account, constructor_customValues)
@@ -127,11 +127,11 @@ TEST(Account, constructor_customValues)
     std::string const bech32Addr = "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx";
 
     Address const address(bech32Addr);
-    Account const account(address, "123456789", 123456789);
+    Account account(address, BigUInt("123456789"), 123456789);
 
     EXPECT_TRUE (account.getAddress() == address);
-    EXPECT_EQ(account.getBalance(), "123456789");
-    EXPECT_EQ(account.getNonce(), 123456789 );
+    EXPECT_EQ(account.getBalance().getValue(), "123456789");
+    EXPECT_EQ(account.getNonce(), 123456789);
 }
 
 TEST(Account, incrementNonce)
@@ -139,15 +139,15 @@ TEST(Account, incrementNonce)
     std::string const bech32Addr = "erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx";
 
     Address const address(bech32Addr);
-    Account account(address, "123456789", 1000);
+    Account account(address, BigUInt("123456789"), 1000);
 
     EXPECT_TRUE (account.getAddress() == address);
-    EXPECT_EQ(account.getBalance(), "123456789");
-    EXPECT_EQ(account.getNonce(), 1000 );
+    EXPECT_EQ(account.getBalance().getValue(), "123456789");
+    EXPECT_EQ(account.getNonce(), 1000);
 
     account.incrementNonce();
 
     EXPECT_TRUE (account.getAddress() == address);
-    EXPECT_EQ(account.getBalance(), "123456789");
-    EXPECT_EQ(account.getNonce(), 1001 );
+    EXPECT_EQ(account.getBalance().getValue(), "123456789");
+    EXPECT_EQ(account.getNonce(), 1001);
 }

--- a/tests/test_src/test_internal/test_internal.cpp
+++ b/tests/test_src/test_internal/test_internal.cpp
@@ -87,3 +87,17 @@ TEST(BigUInt, divmod)
 
     EXPECT_THROW(BigUInt("123").divmod(BigUInt("0")), std::exception);
 }
+
+TEST(BigUInt, div)
+{
+    BigUInt v1(145);
+    BigUInt v2(12);
+
+    BigUInt v3 = v1 / (v2);
+    EXPECT_EQ(v1.getValue(), "145"); // v1's internal value has not change
+    EXPECT_EQ(v2.getValue(), "12"); // v2's internal value has not change
+    EXPECT_TRUE(v3 == BigUInt(12));
+
+    EXPECT_TRUE(BigUInt(4) / BigUInt(4) == BigUInt(1));
+    EXPECT_THROW(BigUInt(4) / BigUInt(0), std::exception);
+}

--- a/tests/test_src/test_provider/test_proxyprovider.cpp
+++ b/tests/test_src/test_provider/test_proxyprovider.cpp
@@ -18,8 +18,8 @@ TEST(ProxyProvider, getAccount)
     Account const account = proxy.getAccount(address);
 
     EXPECT_FALSE(account.getAddress().getBech32Address().empty());
-    EXPECT_FALSE(account.getBalance().empty());
-    EXPECT_FALSE(account.getBalance() == DEFAULT_BALANCE);
+    EXPECT_FALSE(account.getBalance().getValue().empty());
+    EXPECT_FALSE(account.getBalance().getValue() == DEFAULT_BALANCE.getValue());
     EXPECT_FALSE(account.getNonce() == 0);
 }
 
@@ -56,7 +56,7 @@ TEST(ProxyProvider, getESDTokenBalance)
 {
     ProxyProvider proxy("https://testnet-gateway.elrond.com");
     Address const address("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l");
-    auto const balance = proxy.getESDTTokenBalance(address, "this esdt does not exist");
+    BigUInt balance = proxy.getESDTBalance(address, "this esdt does not exist");
 
     EXPECT_TRUE(balance == DEFAULT_BALANCE);
 }
@@ -65,7 +65,7 @@ TEST(ProxyProvider, getAllESDTokenBalances_noTokens)
 {
     ProxyProvider proxy("https://testnet-gateway.elrond.com");
     Address const address("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l");
-    auto const esdts = proxy.getAllESDTTokenBalances(address);
+    auto const esdts = proxy.getAllESDTBalances(address);
 
     EXPECT_TRUE(esdts.empty());
 }
@@ -74,13 +74,13 @@ TEST(ProxyProvider, getAllESDTokenBalances_multipleTokens)
 {
     ProxyProvider proxy("https://testnet-gateway.elrond.com");
     Address const address("erd1nqtv8gdsf55xj9eg0wc8ar6ml46kpld2c86aq670mxgcf49sduzqaeyngx");
-    auto const esdts = proxy.getAllESDTTokenBalances(address);
+    auto const esdts = proxy.getAllESDTBalances(address);
 
     EXPECT_TRUE(esdts.find("00040-4c4d18") != esdts.end());
-    EXPECT_FALSE(esdts.at("00040-4c4d18").empty());
+    EXPECT_FALSE(esdts.at("00040-4c4d18").getValue().empty());
 
     EXPECT_TRUE(esdts.find("0009O-8742a4") != esdts.end());
-    EXPECT_FALSE(esdts.at("0009O-8742a4").empty());
+    EXPECT_FALSE(esdts.at("0009O-8742a4").getValue().empty());
 }
 
 void EXPECT_NETWORK_CONFIG_EQ(const NetworkConfig &cfg1, const NetworkConfig &cfg2)

--- a/tests/test_src/test_provider/test_proxyprovider.cpp
+++ b/tests/test_src/test_provider/test_proxyprovider.cpp
@@ -127,7 +127,7 @@ public:
 
     void EXPECT_TRANSACTION_SENT_SUCCESSFULLY(Transaction const &transaction)
     {
-        std::string const txHash = m_proxy.send(transaction).hash;
+        std::string const txHash = m_proxy.send(transaction);
         EXPECT_FALSE(txHash.empty());
 
         TransactionStatus const txStatus = m_proxy.getTransactionStatus(txHash);
@@ -166,7 +166,7 @@ TEST_F(TestnetProxyProviderTxFixture, send_validTx)
     transaction.m_receiver = std::make_shared<Address>("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l");
     transaction.m_chainID = "T";
     transaction.m_nonce = m_senderAcc.getNonce();
-    transaction.m_value = "10000000000";
+    transaction.m_value = BigUInt("10000000000");
     transaction.m_gasPrice = 1000000000;
     transaction.m_gasLimit = 50000;
 
@@ -181,7 +181,7 @@ TEST_F(TestnetProxyProviderTxFixture, send_validTx_signedHashedTx)
     transaction.m_receiver = std::make_shared<Address>("erd1cux02zersde0l7hhklzhywcxk4u9n4py5tdxyx7vrvhnza2r4gmq4vw35r");
     transaction.m_chainID = "T";
     transaction.m_nonce = m_senderAcc.getNonce();
-    transaction.m_value = "1000000000000";
+    transaction.m_value = BigUInt("1000000000000");
     transaction.m_gasPrice = 1000000000;
     transaction.m_gasLimit = 50000;
     transaction.m_options = std::make_shared<uint32_t>(1U);
@@ -198,7 +198,7 @@ TEST_F(TestnetProxyProviderTxFixture, send_invalidTx_noSignature)
     transaction.m_receiver = std::make_shared<Address>("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l");
     transaction.m_chainID = "T";
     transaction.m_nonce = m_senderAcc.getNonce();
-    transaction.m_value = "10000000000";
+    transaction.m_value = BigUInt("10000000000");
     transaction.m_gasPrice = 1000000000;
     transaction.m_gasLimit = 50000;
 

--- a/tests/test_src/test_transaction/test_transaction.cpp
+++ b/tests/test_src/test_transaction/test_transaction.cpp
@@ -228,7 +228,7 @@ TEST_P(TransactionSignSerializeParametrized, getSignature_serialize)
 
     Transaction transaction;
     transaction.m_nonce =  currParam.nonce;
-    transaction.m_value =  currParam.value;
+    transaction.m_value =  BigUInt(currParam.value);
     transaction.m_receiverUserName =  getPtrBytesFrom(currParam.receiverUserName);
     transaction.m_senderUserName =  getPtrBytesFrom(currParam.senderUserName);
     transaction.m_receiver =  std::make_shared<Address>(currParam.receiver);
@@ -389,7 +389,7 @@ TEST_P(TransactionDeserializeParametrized, deserialize)
     transaction.deserialize(currParam.serializedTx);
 
     EXPECT_EQ(transaction.m_nonce,  currParam.nonce);
-    EXPECT_EQ(transaction.m_value,  currParam.value);
+    EXPECT_EQ(transaction.m_value.getValue(),  currParam.value);
     EXPECT_PTR_BYTE_EQ_STR(transaction.m_receiverUserName,  currParam.receiverUserName);
     EXPECT_PTR_BYTE_EQ_STR(transaction.m_senderUserName,  currParam.senderUserName);
     EXPECT_EQ(transaction.m_receiver->getBech32Address(),  currParam.receiver.getBech32Address());


### PR DESCRIPTION
Replaced balance/value related fields with `BigUInt`, instead of `string` in:
- `ESDT` balance/(s)
- Transaction `value`
- Account `balance`

Additionally:
- Removed `TransactionHash`, which only contained `string hash`
- Added support for `/` operator in `BigUInt`